### PR TITLE
fix: Use RMS-based threshold for blink effect in audio file debug mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/74
-Your prepared branch: issue-74-b55f65db694c
-Your prepared working directory: /tmp/gh-issue-solver-1768094709029
-Your forked repository: konard/Jhon-Crow-audio-recorder-with-visualization
-Original repository (upstream): Jhon-Crow/audio-recorder-with-visualization
-
-Proceed.


### PR DESCRIPTION
## Summary
Fixes the blink effect not triggering when playing audio in debug mode for visualization settings.

**Root Cause:** The audio file debug mode was setting too high a volume threshold because it used peak amplitude (`maxAmp * 255`), but `checkBlinkTrigger` compares against the **average** of frequency bin values (not peak).

**Fix:** Use RMS (Root Mean Square) instead of peak amplitude for threshold calculation:
- RMS better represents average power level
- Applied 0.7 multiplier to account for decibel-to-byte mapping in `getByteFrequencyData()`
- Lowered minimum threshold from 50 to 30 for RMS-based values

## Technical Details

The `analyzeAudioInterval()` function extracts parameters from a selected audio interval:
- **Before:** `volumeThreshold = Math.round(maxAmp * 255)` — used peak amplitude (e.g., 0.8 → 204)
- **After:** `volumeThreshold = Math.round(rms * 255 * 0.7)` — uses RMS with scaling factor

The issue was that Web Audio API's `getByteFrequencyData()` returns values mapped from decibels (-100dB to -30dB by default) to 0-255, and averaging across frequency bins produces values significantly lower than peak amplitude would suggest.

## Test Plan
- [x] All unit tests pass (`npm test` - 67 tests passing)
- [x] Lint passes (`npm run lint`)
- [x] TypeScript type checking passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [ ] Manual test: Load audio file in debug mode, select interval, verify extracted threshold is reasonable
- [ ] Manual test: Play audio file preview, verify blink effect triggers appropriately

## Issue Reference
Fixes Jhon-Crow/audio-recorder-with-visualization#74

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)