### PR TITLE
Add aspect ratio selection

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-04T00:07:17.179Z for PR creation at branch issue-95-dc47c7ee5ed1 for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/95

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-04T00:07:17.179Z for PR creation at branch issue-95-dc47c7ee5ed1 for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/95

--- a/cypress/e2e/aspect-ratio-settings.cy.js
+++ b/cypress/e2e/aspect-ratio-settings.cy.js
@@ -1,0 +1,59 @@
+describe('Aspect Ratio Settings', () => {
+  function selectHiddenOption(selector, value) {
+    cy.get(selector).then(($select) => {
+      $select.val(value);
+      $select[0].dispatchEvent(new Event('change', { bubbles: true }));
+    });
+  }
+
+  beforeEach(() => {
+    cy.clearLocalStorage();
+    cy.visit('/examples/index.html');
+    cy.waitForVisualization();
+  });
+
+  it('defaults to 16:9 and preserves the existing 1080p canvas size', () => {
+    cy.get('#aspectRatio').should('have.value', '16:9');
+    cy.get('#videoDimensions').should('contain.text', '1920 x 1080');
+    cy.get('#visualizer')
+      .should('have.prop', 'width', 1920)
+      .and('have.prop', 'height', 1080);
+  });
+
+  it('switches 1080p output to 9:16 shorts dimensions', () => {
+    selectHiddenOption('#aspectRatio', '9:16');
+
+    cy.get('#videoDimensions').should('contain.text', '608 x 1080');
+    cy.get('#visualizer')
+      .should('have.prop', 'width', 608)
+      .and('have.prop', 'height', 1080);
+
+    cy.window().then((win) => {
+      const saved = JSON.parse(win.localStorage.getItem('audio-recorder-settings'));
+      expect(saved.aspectRatio).to.equal('9:16');
+      expect(win.AudioRecorderApp.getVideoDimensions()).to.deep.equal({ width: 608, height: 1080 });
+    });
+  });
+
+  it('calculates portrait dimensions from the selected quality height', () => {
+    selectHiddenOption('#videoQuality', '720p');
+    selectHiddenOption('#aspectRatio', '4:5');
+
+    cy.get('#videoDimensions').should('contain.text', '576 x 720');
+    cy.window().then((win) => {
+      expect(win.AudioRecorderApp.getVideoDimensions()).to.deep.equal({ width: 576, height: 720 });
+    });
+  });
+
+  it('restores the selected aspect ratio after reload', () => {
+    selectHiddenOption('#aspectRatio', '1:1');
+    cy.reload();
+    cy.waitForVisualization();
+
+    cy.get('#aspectRatio').should('have.value', '1:1');
+    cy.get('#videoDimensions').should('contain.text', '1920 x 1920');
+    cy.get('#visualizer')
+      .should('have.prop', 'width', 1920)
+      .and('have.prop', 'height', 1920);
+  });
+});

--- a/docs/case-studies/issue-95/analysis.md
+++ b/docs/case-studies/issue-95/analysis.md
@@ -1,0 +1,37 @@
+# Issue 95: Aspect Ratio Selection
+
+## Request
+
+The user requested a settings block available for all visualization modes that allows choosing common video aspect ratios, specifically 16:9 and 9:16 for Shorts, without breaking existing behavior.
+
+## Repository Findings
+
+- The example app preview canvas was hardcoded to `1920 x 1080` in `examples/index.html`.
+- Audio-to-video conversion already supports arbitrary `videoWidth` and `videoHeight` through `AudioToVideoConverter.convertWithFallback`.
+- Microphone recording captures the current canvas stream, so resizing the shared canvas is enough to make microphone recordings follow the selected aspect ratio.
+- The existing quality selector only represented 16:9 resolutions.
+
+## External Context
+
+- MDN documents CSS `aspect-ratio` as the standard way to preserve a preferred width-to-height ratio for layout boxes: https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio
+- YouTube Shorts and similar vertical feeds commonly use 9:16, with 1080 x 1920 often used as a high-quality vertical target.
+- Common creator presets worth offering in a general-purpose video tool include 16:9 landscape, 9:16 vertical, 1:1 square, 4:5 portrait, 4:3 classic, and 21:9 ultrawide.
+
+## Chosen Solution
+
+Add an `Aspect Ratio` select next to the existing quality and format controls. Quality continues to choose the maximum long-edge resolution tier, while the aspect ratio derives the missing dimension:
+
+- Landscape ratios keep the quality width and compute height.
+- Portrait ratios keep the quality height and compute width.
+- 16:9 remains the default, preserving the existing 1920 x 1080 behavior for 1080p.
+
+This keeps the public library API unchanged because conversion and recording already accept the resulting dimensions.
+
+## Verification
+
+Added Cypress coverage for:
+
+- Default 16:9 1080p canvas size.
+- 9:16 Shorts dimensions.
+- Portrait ratio calculation at 720p.
+- Persisting and restoring the selected aspect ratio after reload.

--- a/examples/app-core.js
+++ b/examples/app-core.js
@@ -72,6 +72,8 @@ window.AudioRecorderApp = window.AudioRecorderApp || {};
   const loopPreviewCheckbox = document.getElementById('loopPreview');
   const progressFill = document.getElementById('progressFill');
   const videoQuality = document.getElementById('videoQuality');
+  const aspectRatio = document.getElementById('aspectRatio');
+  const videoDimensions = document.getElementById('videoDimensions');
   const bgSizeMode = document.getElementById('bgSizeMode');
   const customSizeControls = document.getElementById('customSizeControls');
   const bgCustomWidth = document.getElementById('bgCustomWidth');
@@ -173,6 +175,7 @@ window.AudioRecorderApp = window.AudioRecorderApp || {};
     backgroundWidth: 800,
     backgroundHeight: 400,
     videoQuality: '1080p',
+    aspectRatio: '16:9',
     videoFormat: 'webm',
     layerEffect: 'none',
     layerEffectIntensity: 50,
@@ -337,6 +340,7 @@ window.AudioRecorderApp = window.AudioRecorderApp || {};
       backgroundWidth: parseInt(bgCustomWidth.value),
       backgroundHeight: parseInt(bgCustomHeight.value),
       videoQuality: videoQuality.value,
+      aspectRatio: aspectRatio.value,
       videoFormat: videoFormat.value,
       layerEffect: layerEffect.value,
       layerEffectIntensity: parseInt(layerEffectIntensity.value),
@@ -409,6 +413,7 @@ window.AudioRecorderApp = window.AudioRecorderApp || {};
     bgCustomWidth.value = settings.backgroundWidth || 800;
     bgCustomHeight.value = settings.backgroundHeight || 400;
     videoQuality.value = settings.videoQuality || '1080p';
+    aspectRatio.value = settings.aspectRatio || '16:9';
     layerEffect.value = settings.layerEffect || 'none';
     layerEffectIntensity.value = settings.layerEffectIntensity || 50;
     layerEffectIntensityValue.textContent = (settings.layerEffectIntensity || 50) + '%';
@@ -516,9 +521,50 @@ window.AudioRecorderApp = window.AudioRecorderApp || {};
   // Initialize accordions
   initializeAccordions();
 
+  const qualityDimensions = {
+    '720p': { width: 1280, height: 720 },
+    '1080p': { width: 1920, height: 1080 },
+    '1440p': { width: 2560, height: 1440 },
+    '2160p': { width: 3840, height: 2160 },
+  };
+
+  function getVideoDimensions() {
+    const base = qualityDimensions[videoQuality.value] || qualityDimensions['1080p'];
+    const [ratioWidth, ratioHeight] = (aspectRatio.value || '16:9')
+      .split(':')
+      .map(value => parseInt(value, 10));
+
+    if (!ratioWidth || !ratioHeight) {
+      return base;
+    }
+
+    if (ratioWidth >= ratioHeight) {
+      return {
+        width: base.width,
+        height: Math.round(base.width * ratioHeight / ratioWidth),
+      };
+    }
+
+    return {
+      width: Math.round(base.height * ratioWidth / ratioHeight),
+      height: base.height,
+    };
+  }
+
+  function applyVideoDimensions(redraw = true) {
+    const dimensions = getVideoDimensions();
+    canvas.width = dimensions.width;
+    canvas.height = dimensions.height;
+    videoDimensions.textContent = `${dimensions.width} x ${dimensions.height}`;
+    if (redraw) {
+      updatePreview();
+    }
+  }
+
   // Load and apply saved settings on startup
   const savedSettings = loadSettings();
   applySettings(savedSettings);
+  applyVideoDimensions(false);
 
   // Tab switching
   document.querySelectorAll('.tab').forEach(tab => {
@@ -1002,6 +1048,8 @@ window.AudioRecorderApp = window.AudioRecorderApp || {};
     updateStatus,
     updateButtonStates,
     addRecording,
+    getVideoDimensions,
+    applyVideoDimensions,
     // Elements (for other modules)
     elements: {
       visualizerSelect,
@@ -1041,6 +1089,8 @@ window.AudioRecorderApp = window.AudioRecorderApp || {};
       loopPreviewCheckbox,
       progressFill,
       videoQuality,
+      aspectRatio,
+      videoDimensions,
       bgSizeMode,
       customSizeControls,
       bgCustomWidth,

--- a/examples/app-features.js
+++ b/examples/app-features.js
@@ -204,6 +204,13 @@ function initFeatures() {
     updatePreview();
   });
 
+  [el.videoQuality, el.aspectRatio].forEach(elem => {
+    elem.addEventListener('change', () => {
+      app.applyVideoDimensions();
+      saveSettings(getCurrentSettings());
+    });
+  });
+
   // Layer effect intensity handler with display update
   el.layerEffectIntensity.addEventListener('input', () => {
     const intensity = parseInt(el.layerEffectIntensity.value);

--- a/examples/app-interactions.js
+++ b/examples/app-interactions.js
@@ -402,14 +402,7 @@ function initInteractions() {
     }
 
     try {
-      // Get video dimensions based on quality setting
-      const qualityMap = {
-        '720p': { width: 1280, height: 720 },
-        '1080p': { width: 1920, height: 1080 },
-        '1440p': { width: 2560, height: 1440 },
-        '2160p': { width: 3840, height: 2160 },
-      };
-      const quality = qualityMap[el.videoQuality.value] || qualityMap['1080p'];
+      const dimensions = app.getVideoDimensions();
 
       const result = await converter.convertWithFallback({
         audioSource: file,
@@ -417,8 +410,8 @@ function initInteractions() {
         visualizer: el.visualizerSelect.value,
         visualizerOptions: getCurrentOptions(),
         fps: 30,
-        videoWidth: quality.width,
-        videoHeight: quality.height,
+        videoWidth: dimensions.width,
+        videoHeight: dimensions.height,
         format: el.videoFormat.value,
         onProgress: updateProgress,
       });

--- a/examples/index.html
+++ b/examples/index.html
@@ -56,6 +56,18 @@
             </select>
           </label>
           <label>
+            Aspect Ratio
+            <select id="aspectRatio" aria-label="Select video aspect ratio">
+              <option value="16:9" selected>16:9 Landscape</option>
+              <option value="9:16">9:16 Shorts / Vertical</option>
+              <option value="1:1">1:1 Square</option>
+              <option value="4:5">4:5 Portrait</option>
+              <option value="4:3">4:3 Classic</option>
+              <option value="21:9">21:9 Ultrawide</option>
+            </select>
+          </label>
+          <div class="dimension-summary" id="videoDimensions" aria-live="polite">1920 x 1080</div>
+          <label>
             Video Format
             <select id="videoFormat" aria-label="Select video format">
               <option value="webm" selected>WebM (VP9/VP8)</option>

--- a/examples/styles.css
+++ b/examples/styles.css
@@ -396,6 +396,19 @@ button:focus-visible {
   box-shadow: 0 0 0 3px rgba(0, 255, 136, 0.1);
 }
 
+.dimension-summary {
+  align-self: end;
+  min-height: 44px;
+  padding: 12px var(--spacing-md);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: rgba(0, 0, 0, 0.3);
+  color: var(--color-text-secondary);
+  font-size: 13px;
+  font-weight: 600;
+  text-align: center;
+}
+
 .option-group input[type="color"] {
   height: 44px;
   cursor: pointer;


### PR DESCRIPTION
Fixes Jhon-Crow/audio-recorder-with-visualization#95\n\n## Summary\n- Added an Aspect Ratio selector with common presets, including 16:9 and 9:16 Shorts / Vertical.\n- Resize the shared preview/recording canvas from the selected quality and aspect ratio, while keeping 16:9 1080p as the default behavior.\n- Use the computed dimensions for audio-to-video conversion output.\n- Added issue-95 case-study notes under docs/case-studies/issue-95.\n\n## Tests\n- npm run typecheck\n- npm test -- --runInBand\n- npm run build\n- npx cypress run --spec cypress/e2e/aspect-ratio-settings.cy.js\n