### PR TITLE
Fix active preset highlight after app restart

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-06T10:18:40.343Z for PR creation at branch issue-113-94b03c93afe6 for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/113

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-06T10:18:40.343Z for PR creation at branch issue-113-94b03c93afe6 for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/113

--- a/cypress/e2e/preset-management.cy.js
+++ b/cypress/e2e/preset-management.cy.js
@@ -1,4 +1,12 @@
 describe('Preset Management', () => {
+  function visitWithPresets(presets) {
+    cy.window().then((win) => {
+      win.localStorage.setItem('audio-recorder-presets', JSON.stringify(presets));
+    });
+    cy.reload();
+    cy.waitForVisualization();
+  }
+
   beforeEach(() => {
     cy.clearLocalStorage();
     cy.visit('/examples/index.html');
@@ -49,15 +57,11 @@ describe('Preset Management', () => {
   });
 
   it('renames, deletes, and reorders presets from the sidebar', () => {
-    cy.window().then((win) => {
-      win.localStorage.setItem('audio-recorder-presets', JSON.stringify([
-        { id: 'preset-a', name: 'A', createdAt: '2026-06-04T00:00:00.000Z', settings: {} },
-        { id: 'preset-b', name: 'B', createdAt: '2026-06-04T00:00:01.000Z', settings: {} },
-        { id: 'preset-c', name: 'C', createdAt: '2026-06-04T00:00:02.000Z', settings: {} },
-      ]));
-    });
-    cy.reload();
-    cy.waitForVisualization();
+    visitWithPresets([
+      { id: 'preset-a', name: 'A', createdAt: '2026-06-04T00:00:00.000Z', settings: {} },
+      { id: 'preset-b', name: 'B', createdAt: '2026-06-04T00:00:01.000Z', settings: {} },
+      { id: 'preset-c', name: 'C', createdAt: '2026-06-04T00:00:02.000Z', settings: {} },
+    ]);
     cy.window().then((win) => {
       cy.stub(win, 'confirm').returns(true);
     });
@@ -98,19 +102,15 @@ describe('Preset Management', () => {
   });
 
   it('highlights the loaded preset until settings change', () => {
-    cy.window().then((win) => {
-      win.localStorage.setItem('audio-recorder-presets', JSON.stringify([
-        { id: 'preset-a', name: 'A', createdAt: '2026-06-04T00:00:00.000Z', settings: {} },
-        {
-          id: 'preset-b',
-          name: 'B',
-          createdAt: '2026-06-04T00:00:01.000Z',
-          settings: { visualizer: 'waveform', primaryColor: '#ff0000' },
-        },
-      ]));
-    });
-    cy.reload();
-    cy.waitForVisualization();
+    visitWithPresets([
+      { id: 'preset-a', name: 'A', createdAt: '2026-06-04T00:00:00.000Z', settings: {} },
+      {
+        id: 'preset-b',
+        name: 'B',
+        createdAt: '2026-06-04T00:00:01.000Z',
+        settings: { visualizer: 'waveform', primaryColor: '#ff0000' },
+      },
+    ]);
     cy.get('#presetEdgeTrigger').trigger('pointerenter');
 
     cy.get('#presetList .preset-load-btn').first().click();
@@ -122,5 +122,45 @@ describe('Preset Management', () => {
     cy.get('#presetList .preset-load-btn').first()
       .should('not.have.class', 'is-active')
       .and('not.have.attr', 'aria-current');
+  });
+
+  it('restores the active preset highlight after reload when settings still match', () => {
+    visitWithPresets([
+      {
+        id: 'preset-a',
+        name: 'A',
+        createdAt: '2026-06-04T00:00:00.000Z',
+        settings: { visualizer: 'waveform', primaryColor: '#ff0000' },
+      },
+      {
+        id: 'preset-b',
+        name: 'B',
+        createdAt: '2026-06-04T00:00:01.000Z',
+        settings: { visualizer: 'bars', primaryColor: '#00ff88' },
+      },
+    ]);
+    cy.get('#presetEdgeTrigger').trigger('pointerenter');
+
+    cy.get('#presetList .preset-load-btn').first().click();
+    cy.get('#presetList .preset-load-btn').first()
+      .should('have.class', 'is-active')
+      .and('have.attr', 'aria-current', 'true');
+
+    cy.reload();
+    cy.waitForVisualization();
+    cy.get('#presetEdgeTrigger').trigger('pointerenter');
+
+    cy.get('#presetList .preset-load-btn').first()
+      .should('have.class', 'is-active')
+      .and('have.attr', 'aria-current', 'true');
+
+    cy.get('#visualizerSelect').select('bars');
+    cy.get('#presetList .preset-load-btn').first()
+      .should('not.have.class', 'is-active')
+      .and('not.have.attr', 'aria-current');
+
+    cy.window().then((win) => {
+      expect(win.localStorage.getItem('audio-recorder-active-preset-id')).to.equal(null);
+    });
   });
 });

--- a/examples/app-core.js
+++ b/examples/app-core.js
@@ -195,6 +195,7 @@ window.AudioRecorderApp = window.AudioRecorderApp || {};
   const ACCORDION_STATE_KEY = 'audio-recorder-accordion-states';
   const PRESETS_KEY = 'audio-recorder-presets';
   const PRESET_OPTIONS_KEY = 'audio-recorder-preset-options';
+  const ACTIVE_PRESET_KEY = 'audio-recorder-active-preset-id';
 
   // Default settings
   const defaultSettings = {
@@ -328,6 +329,27 @@ window.AudioRecorderApp = window.AudioRecorderApp || {};
     }
   }
 
+  function loadActivePresetId() {
+    try {
+      return localStorage.getItem(ACTIVE_PRESET_KEY);
+    } catch (error) {
+      console.warn('Failed to load active preset:', error);
+      return null;
+    }
+  }
+
+  function saveActivePresetId(presetId) {
+    try {
+      if (presetId) {
+        localStorage.setItem(ACTIVE_PRESET_KEY, presetId);
+      } else {
+        localStorage.removeItem(ACTIVE_PRESET_KEY);
+      }
+    } catch (error) {
+      console.warn('Failed to save active preset:', error);
+    }
+  }
+
   // Accordion state management
   function loadAccordionStates() {
     try {
@@ -413,7 +435,7 @@ window.AudioRecorderApp = window.AudioRecorderApp || {};
   let presets = loadPresets();
   let presetOptions = loadPresetOptions();
   let activePresetMenuId = null;
-  let activeLoadedPresetId = null;
+  let activeLoadedPresetId = loadActivePresetId();
   let presetRenameTargetId = null;
   let draggedPresetId = null;
   let presetSidebarCloseTimer = null;
@@ -515,17 +537,35 @@ window.AudioRecorderApp = window.AudioRecorderApp || {};
       JSON.stringify(sortSerializableValue(normalizeSettings(rightSettings)));
   }
 
+  function savedPresetFieldsMatch(currentSettings, presetSettings = {}) {
+    if (Object.keys(presetSettings || {}).length === 0) {
+      return settingsMatch(currentSettings, presetSettings);
+    }
+
+    const normalizedCurrent = sortSerializableValue(normalizeSettings(currentSettings));
+    const normalizedPreset = sortSerializableValue(presetSettings || {});
+
+    return Object.keys(normalizedPreset).every(key => (
+      JSON.stringify(normalizedCurrent[key]) === JSON.stringify(normalizedPreset[key])
+    ));
+  }
+
   function isPresetCurrentlyActive(preset) {
     return Boolean(
       activeLoadedPresetId &&
       preset &&
       preset.id === activeLoadedPresetId &&
-      settingsMatch(getCurrentSettings(), preset.settings)
+      savedPresetFieldsMatch(getCurrentSettings(), preset.settings)
     );
   }
 
   function updateActivePresetIndicator() {
     const buttons = presetList.querySelectorAll('.preset-load-btn');
+    const activePreset = presets.find(item => item.id === activeLoadedPresetId);
+    if (activeLoadedPresetId && !isPresetCurrentlyActive(activePreset)) {
+      activeLoadedPresetId = null;
+      saveActivePresetId(null);
+    }
 
     buttons.forEach(button => {
       const preset = presets.find(item => item.id === button.dataset.presetId);
@@ -1343,6 +1383,7 @@ window.AudioRecorderApp = window.AudioRecorderApp || {};
     presets = presets.filter(item => item.id !== presetId);
     if (activeLoadedPresetId === presetId) {
       activeLoadedPresetId = null;
+      saveActivePresetId(null);
     }
     savePresets(presets);
     renderPresets();
@@ -1458,6 +1499,7 @@ window.AudioRecorderApp = window.AudioRecorderApp || {};
 
     presets = [...presets, preset];
     activeLoadedPresetId = preset.id;
+    saveActivePresetId(activeLoadedPresetId);
     savePresets(presets);
     await persistPresetToFolder(preset);
     renderPresets();
@@ -1472,6 +1514,8 @@ window.AudioRecorderApp = window.AudioRecorderApp || {};
     }
 
     const settings = { ...defaultSettings, ...preset.settings };
+    activeLoadedPresetId = preset.id;
+    saveActivePresetId(activeLoadedPresetId);
     applySettings(settings);
     saveSettings(settings);
     await recorder.setVisualizer(visualizerSelect.value, getCurrentOptions());
@@ -1480,7 +1524,6 @@ window.AudioRecorderApp = window.AudioRecorderApp || {};
     updateSliderColors();
     updateButtonStates();
     updatePreview();
-    activeLoadedPresetId = preset.id;
     updateActivePresetIndicator();
     updateStatus(`Preset "${preset.name}" loaded`, 'ready');
   }


### PR DESCRIPTION
## Summary
- persist the active loaded preset id in localStorage
- restore the active preset highlight after reload when saved settings still match
- clear the persisted active preset when settings diverge or the preset is deleted
- add Cypress coverage for active preset restoration across reloads

Fixes Jhon-Crow/audio-recorder-with-visualization#113

## Verification
- npx cypress run --spec cypress/e2e/preset-management.cy.js
- npm test
- npm run typecheck
- npm run build