### PR TITLE
Use #shorts for YouTube Shorts uploads

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-06T18:06:48.985Z for PR creation at branch issue-115-9ee3eb4ba9cb for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/115

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-06T18:06:48.985Z for PR creation at branch issue-115-9ee3eb4ba9cb for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/115

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ const result = await uploader.upload({
     description: 'Rendered with audio-recorder-with-visualization',
     tags: ['audio', 'visualizer'],
     privacyStatus: 'private',
-    short: true, // appends #short to the description
+    short: true, // appends #shorts to the description
   },
   onProgress: ({ percent }) => {
     console.log(`Uploaded ${Math.round(percent * 100)}%`);

--- a/cypress/e2e/youtube-upload-ui.cy.js
+++ b/cypress/e2e/youtube-upload-ui.cy.js
@@ -165,7 +165,7 @@ describe('YouTube Upload UI', () => {
 
       expect(req.headers.authorization).to.equal('Bearer test-token');
       expect(body.snippet.title).to.equal('Published visualizer');
-      expect(body.snippet.description).to.equal('Rendered from Cypress\n\n#short');
+      expect(body.snippet.description).to.equal('Rendered from Cypress\n\n#shorts');
       expect(body.snippet.tags).to.deep.equal(['audio', 'visualizer', 'cypress']);
       expect(body.status.privacyStatus).to.equal('unlisted');
       expect(body.status.selfDeclaredMadeForKids).to.equal(false);

--- a/examples/index.html
+++ b/examples/index.html
@@ -775,7 +775,7 @@
               <input type="text" id="youtubeTags" aria-label="YouTube video tags">
             </label>
             <label class="youtube-checkbox">
-              <input type="checkbox" id="youtubeShort" aria-label="Mark as YouTube Short"> Short (#short)
+              <input type="checkbox" id="youtubeShort" aria-label="Mark as YouTube Short"> Short (#shorts)
             </label>
             <label class="youtube-checkbox">
               <input type="checkbox" id="youtubeMadeForKids" aria-label="Made for kids"> Made for kids

--- a/src/core/YouTubeUploader.ts
+++ b/src/core/YouTubeUploader.ts
@@ -4,7 +4,7 @@
 
 export const YOUTUBE_UPLOAD_SCOPE = 'https://www.googleapis.com/auth/youtube.upload';
 export const YOUTUBE_UPLOAD_ENDPOINT = 'https://www.googleapis.com/upload/youtube/v3/videos';
-export const YOUTUBE_SHORT_HASHTAG = '#short';
+export const YOUTUBE_SHORT_HASHTAG = '#shorts';
 
 const DEFAULT_CATEGORY_ID = '10';
 const DEFAULT_CHUNK_SIZE = 8 * 1024 * 1024;

--- a/tests/YouTubeUploader.test.ts
+++ b/tests/YouTubeUploader.test.ts
@@ -44,9 +44,10 @@ describe('YouTubeUploader', () => {
       ]);
     });
 
-    test('appends #short to descriptions only when enabled and not already present', () => {
-      expect(appendShortHashtag('Demo description', true)).toBe('Demo description\n\n#short');
+    test('appends #shorts to descriptions only when enabled and not already present', () => {
+      expect(appendShortHashtag('Demo description', true)).toBe('Demo description\n\n#shorts');
       expect(appendShortHashtag('Demo #shorts', true)).toBe('Demo #shorts');
+      expect(appendShortHashtag('Demo #short', true)).toBe('Demo #short');
       expect(appendShortHashtag('Demo description', false)).toBe('Demo description');
     });
 
@@ -61,7 +62,7 @@ describe('YouTubeUploader', () => {
       expect(resource).toEqual({
         snippet: {
           title: 'Audio visualizer',
-          description: 'Rendered with the app\n\n#short',
+          description: 'Rendered with the app\n\n#shorts',
           tags: ['audio', 'visualizer'],
           categoryId: '10',
         },
@@ -126,7 +127,7 @@ describe('YouTubeUploader', () => {
       });
 
       const sessionBody = JSON.parse(sessionInit.body as string);
-      expect(sessionBody.snippet.description).toBe('Demo\n\n#short');
+      expect(sessionBody.snippet.description).toBe('Demo\n\n#shorts');
       expect(sessionBody.status.privacyStatus).toBe('unlisted');
 
       const uploadInit = fetchMock.mock.calls[1][1] as RequestInit;


### PR DESCRIPTION
## Summary
- Change the YouTube Shorts metadata helper to append `#shorts` instead of `#short` when the Short checkbox is enabled.
- Update the upload modal label, README example, and Cypress expectation to match the emitted Shorts signal.
- Keep existing detection of either `#short` or `#shorts` in user descriptions so duplicate hashtags are not added.

Fixes Jhon-Crow/audio-recorder-with-visualization#115

## Reproduction
Before the fix, enabling the Short checkbox produced an upload session body with `snippet.description` ending in `#short`. The focused Jest assertions were updated to expect the canonical `#shorts` Shorts signal and failed against the old implementation.

## Tests
- `npm test -- --runTestsByPath tests/YouTubeUploader.test.ts`
- `npm run typecheck`
- `npm run build`
- `npm test`