### PR TITLE
Add YouTube video preview thumbnail upload

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-06T18:09:02.137Z for PR creation at branch issue-118-f1d07ac6dab1 for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/118

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-06T18:09:02.137Z for PR creation at branch issue-118-f1d07ac6dab1 for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/118

--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ import { YouTubeUploader, YOUTUBE_UPLOAD_SCOPE } from 'audio-recorder-with-visua
 const uploader = new YouTubeUploader();
 const result = await uploader.upload({
   video: videoBlob,
+  thumbnail: thumbnailBlob, // optional JPEG, PNG, or WebP preview image
   accessToken,
   metadata: {
     title: 'Audio visualizer',

--- a/cypress/e2e/youtube-upload-ui.cy.js
+++ b/cypress/e2e/youtube-upload-ui.cy.js
@@ -187,6 +187,16 @@ describe('YouTube Upload UI', () => {
       });
     }).as('finishYouTubeUpload');
 
+    cy.intercept('POST', 'https://www.googleapis.com/upload/youtube/v3/thumbnails/set?videoId=video-abc', (req) => {
+      expect(req.headers.authorization).to.equal('Bearer test-token');
+      expect(req.headers['content-type']).to.contain('image/png');
+
+      req.reply({
+        statusCode: 200,
+        body: { items: [{ default: true }] },
+      });
+    }).as('setYouTubeThumbnail');
+
     cy.visit('/examples/index.html', {
       onBeforeLoad(win) {
         win.google = {
@@ -221,12 +231,18 @@ describe('YouTube Upload UI', () => {
     cy.get('#youtubeTitle').clear().type('Published visualizer');
     cy.get('#youtubeDescription').type('Rendered from Cypress');
     cy.get('#youtubeTags').clear().type('audio, visualizer, cypress');
+    cy.get('#youtubeThumbnail').selectFile({
+      contents: Cypress.Buffer.from('preview-image'),
+      fileName: 'preview.png',
+      mimeType: 'image/png',
+    });
     cy.get('#youtubePrivacy').select('unlisted');
     cy.get('#youtubeShort').check();
     cy.get('#submitYouTubeUploadBtn').click();
 
     cy.wait('@startYouTubeUpload');
     cy.wait('@finishYouTubeUpload');
+    cy.wait('@setYouTubeThumbnail');
     cy.get('#youtubeUploadStatus')
       .should('contain.text', 'Uploaded:')
       .find('a')

--- a/examples/index.html
+++ b/examples/index.html
@@ -774,6 +774,10 @@
               Tags
               <input type="text" id="youtubeTags" aria-label="YouTube video tags">
             </label>
+            <label class="youtube-wide-field">
+              Video Preview
+              <input type="file" id="youtubeThumbnail" accept="image/jpeg,image/png,image/webp" aria-label="YouTube video preview image">
+            </label>
             <label class="youtube-checkbox">
               <input type="checkbox" id="youtubeShort" aria-label="Mark as YouTube Short"> Short (#short)
             </label>

--- a/examples/youtube-upload.js
+++ b/examples/youtube-upload.js
@@ -38,6 +38,7 @@
   const titleInput = document.getElementById('youtubeTitle');
   const descriptionInput = document.getElementById('youtubeDescription');
   const tagsInput = document.getElementById('youtubeTags');
+  const thumbnailInput = document.getElementById('youtubeThumbnail');
   const categorySelect = document.getElementById('youtubeCategory');
   const privacySelect = document.getElementById('youtubePrivacy');
   const shortCheckbox = document.getElementById('youtubeShort');
@@ -53,7 +54,7 @@
   const requiredElements = [
     authModal, closeAuthBtn, cancelAuthBtn, openGoogleCloudOAuthBtn, authorizeBtn,
     clientIdInput, clientSecretField, clientSecretInput, authStatus,
-    uploadModal, closeUploadBtn, uploadForm, titleInput, descriptionInput, tagsInput,
+    uploadModal, closeUploadBtn, uploadForm, titleInput, descriptionInput, tagsInput, thumbnailInput,
     categorySelect, privacySelect, shortCheckbox, madeForKidsCheckbox, syntheticMediaCheckbox,
     notifySubscribersCheckbox, progressBar, progressFill, uploadStatus, cancelUploadBtn,
     submitUploadBtn,
@@ -275,6 +276,7 @@
     titleInput.value = getDefaultTitle(pendingUpload.fileName);
     descriptionInput.value = '';
     tagsInput.value = 'audio, visualizer';
+    thumbnailInput.value = '';
     categorySelect.value = '10';
     privacySelect.value = 'private';
     shortCheckbox.checked = shouldDefaultToShort();
@@ -449,6 +451,7 @@
     try {
       const result = await uploader.upload({
         video: pendingUpload.blob,
+        thumbnail: thumbnailInput.files && thumbnailInput.files[0] ? thumbnailInput.files[0] : undefined,
         accessToken,
         metadata: collectMetadata(),
         notifySubscribers: notifySubscribersCheckbox.checked,

--- a/src/core/YouTubeUploader.ts
+++ b/src/core/YouTubeUploader.ts
@@ -4,6 +4,7 @@
 
 export const YOUTUBE_UPLOAD_SCOPE = 'https://www.googleapis.com/auth/youtube.upload';
 export const YOUTUBE_UPLOAD_ENDPOINT = 'https://www.googleapis.com/upload/youtube/v3/videos';
+export const YOUTUBE_THUMBNAIL_UPLOAD_ENDPOINT = 'https://www.googleapis.com/upload/youtube/v3/thumbnails/set';
 export const YOUTUBE_SHORT_HASHTAG = '#short';
 
 const DEFAULT_CATEGORY_ID = '10';
@@ -33,6 +34,7 @@ export interface YouTubeUploadProgress {
 
 export interface YouTubeUploadRequest {
   video: Blob;
+  thumbnail?: Blob;
   accessToken: string;
   metadata: YouTubeUploadMetadata;
   notifySubscribers?: boolean;
@@ -44,6 +46,7 @@ export interface YouTubeUploadRequest {
 export interface YouTubeUploadResult {
   id: string;
   url: string;
+  thumbnail?: unknown;
   rawResponse: unknown;
 }
 
@@ -66,6 +69,7 @@ type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Respo
 export interface YouTubeUploaderConfig {
   fetch?: FetchLike;
   uploadEndpoint?: string;
+  thumbnailUploadEndpoint?: string;
 }
 
 export class YouTubeUploadError extends Error {
@@ -169,10 +173,12 @@ export function getYouTubeWatchUrl(videoId: string): string {
 export class YouTubeUploader {
   private readonly fetchImpl?: FetchLike;
   private readonly uploadEndpoint: string;
+  private readonly thumbnailUploadEndpoint: string;
 
   constructor(config: YouTubeUploaderConfig = {}) {
     this.fetchImpl = config.fetch;
     this.uploadEndpoint = config.uploadEndpoint || YOUTUBE_UPLOAD_ENDPOINT;
+    this.thumbnailUploadEndpoint = config.thumbnailUploadEndpoint || YOUTUBE_THUMBNAIL_UPLOAD_ENDPOINT;
   }
 
   async upload(request: YouTubeUploadRequest): Promise<YouTubeUploadResult> {
@@ -204,7 +210,19 @@ export class YouTubeUploader {
       stage: 'session',
     });
 
-    return this.uploadChunks(fetchImpl, uploadUrl, request, contentType);
+    const result = await this.uploadChunks(fetchImpl, uploadUrl, request, contentType);
+
+    if (request.thumbnail && request.thumbnail.size > 0) {
+      result.thumbnail = await this.uploadThumbnail(
+        fetchImpl,
+        request.accessToken,
+        result.id,
+        request.thumbnail,
+        request.signal
+      );
+    }
+
+    return result;
   }
 
   private getFetch(): FetchLike {
@@ -317,6 +335,33 @@ export class YouTubeUploader {
     const details = await readResponseBody(response);
     const message = extractErrorMessage(details) || fallbackMessage;
     return new YouTubeUploadError(message, response.status, details);
+  }
+
+  private async uploadThumbnail(
+    fetchImpl: FetchLike,
+    accessToken: string,
+    videoId: string,
+    thumbnail: Blob,
+    signal?: AbortSignal
+  ): Promise<unknown> {
+    const url = new URL(this.thumbnailUploadEndpoint);
+    url.searchParams.set('videoId', videoId);
+
+    const response = await fetchImpl(url.toString(), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': thumbnail.type || 'application/octet-stream',
+      },
+      body: thumbnail,
+      signal,
+    });
+
+    if (!response.ok) {
+      throw await this.createError(response, 'Unable to set YouTube video thumbnail');
+    }
+
+    return readResponseBody(response);
   }
 }
 

--- a/tests/YouTubeUploader.test.ts
+++ b/tests/YouTubeUploader.test.ts
@@ -140,6 +140,45 @@ describe('YouTubeUploader', () => {
       expect(progress[progress.length - 1]).toMatchObject({ percent: 1, stage: 'complete' });
     });
 
+    test('sets a custom video thumbnail after uploading the video', async () => {
+      const fetchMock = createFetchMock();
+      fetchMock
+        .mockResolvedValueOnce(createResponse(null, {
+          status: 200,
+          headers: { Location: 'https://upload.example/session' },
+        }))
+        .mockResolvedValueOnce(createResponse(JSON.stringify({ id: 'video-123' }), {
+          status: 201,
+        }))
+        .mockResolvedValueOnce(createResponse(JSON.stringify({ items: [{ default: true }] }), {
+          status: 200,
+        }));
+
+      const uploader = new YouTubeUploader({ fetch: fetchMock });
+      const thumbnail = new Blob(['image'], { type: 'image/png' });
+
+      const result = await uploader.upload({
+        video: new Blob(['video'], { type: 'video/webm' }),
+        thumbnail,
+        accessToken: 'token-123',
+        metadata: { title: 'Audio visualizer' },
+      });
+
+      expect(result.thumbnail).toEqual({ items: [{ default: true }] });
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(String(fetchMock.mock.calls[2][0])).toBe(
+        'https://www.googleapis.com/upload/youtube/v3/thumbnails/set?videoId=video-123',
+      );
+
+      const thumbnailInit = fetchMock.mock.calls[2][1] as RequestInit;
+      expect(thumbnailInit.method).toBe('POST');
+      expect(thumbnailInit.headers).toMatchObject({
+        Authorization: 'Bearer token-123',
+        'Content-Type': 'image/png',
+      });
+      expect(thumbnailInit.body).toBe(thumbnail);
+    });
+
     test('continues after a 308 resumable response', async () => {
       const fetchMock = createFetchMock();
       fetchMock


### PR DESCRIPTION
Fixes Jhon-Crow/audio-recorder-with-visualization#118

## Summary
- Added optional `thumbnail` support to `YouTubeUploader.upload()`, uploading it through YouTube Data API `thumbnails.set` after the video insert completes.
- Added a Video Preview image picker to the example YouTube upload form and pass the selected JPEG/PNG/WebP file with the upload request.
- Added unit and Cypress coverage for setting a custom thumbnail during the YouTube upload flow.
- Documented the optional thumbnail blob in the README usage example.

## Reproduction
Before this change, the YouTube upload modal exposed title, privacy, category, description, tags, and policy options, but no field for selecting a preview/thumbnail image. The uploader API also had no thumbnail request path, so callers could only upload the video resource itself.

## Verification
- `npm test -- YouTubeUploader.test.ts`
- `npm run typecheck`
- `npm run build`
- `npx cypress run --spec cypress/e2e/youtube-upload-ui.cy.js`
- `npm test`
