### PR TITLE
Persist Google authorization for YouTube uploads

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-06T18:34:48.700Z for PR creation at branch issue-121-103004f9fc01 for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/121

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-06T18:34:48.700Z for PR creation at branch issue-121-103004f9fc01 for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/121

--- a/cypress/e2e/youtube-upload-ui.cy.js
+++ b/cypress/e2e/youtube-upload-ui.cy.js
@@ -159,6 +159,65 @@ describe('YouTube Upload UI', () => {
     cy.get('#youtubeUploadModal').should('be.visible');
   });
 
+  it('restores saved Google authorization after a restart', () => {
+    const futureExpiry = Date.now() + 3600 * 1000;
+
+    cy.visit('/examples/index.html', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('audio-recorder-youtube-client-id', '123-test-client-id.apps.googleusercontent.com');
+        win.localStorage.setItem('audio-recorder-youtube-token-state', JSON.stringify({
+          accessToken: 'stored-token',
+          accessTokenExpiresAt: futureExpiry,
+        }));
+      },
+    });
+    cy.waitForVisualization();
+
+    addSyntheticRecording();
+    cy.contains('button', 'Upload to YouTube').click();
+
+    cy.get('#youtubeUploadModal').should('be.visible');
+    cy.get('#youtubeAuthModal').should('not.be.visible');
+    cy.get('#youtubeAuthSettingsStatus').should('contain.text', 'Signed in');
+  });
+
+  it('signs out from Google authorization settings', () => {
+    const futureExpiry = Date.now() + 3600 * 1000;
+
+    cy.visit('/examples/index.html', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('audio-recorder-youtube-token-state', JSON.stringify({
+          accessToken: 'stored-token',
+          accessTokenExpiresAt: futureExpiry,
+        }));
+        win.electronAPI = {
+          isElectron: true,
+          authorizeYouTube: cy.stub().as('authorizeYouTube').resolves({
+            accessToken: 'electron-token',
+            expiresIn: 3600,
+          }),
+          clearYouTubeAuthorization: cy.stub().as('clearYouTubeAuthorization').resolves({ success: true }),
+        };
+      },
+    });
+    cy.waitForVisualization();
+
+    addSyntheticRecording();
+    cy.contains('button', 'Upload to YouTube').click();
+    cy.get('#youtubeUploadModal').should('be.visible');
+    cy.get('#youtubeUploadModal .close-btn').click();
+
+    cy.get('#youtubeAuthModal').invoke('show');
+    cy.get('#youtubeAuthSettingsStatus').should('contain.text', 'Signed in');
+    cy.get('#youtubeSignOutBtn').click();
+
+    cy.get('@clearYouTubeAuthorization').should('have.been.calledOnce');
+    cy.window().then((win) => {
+      expect(win.localStorage.getItem('audio-recorder-youtube-token-state')).to.equal(null);
+    });
+    cy.get('#youtubeAuthSettingsStatus').should('contain.text', 'Not signed in');
+  });
+
   it('authorizes with Google and uploads metadata with the short tag enabled', () => {
     cy.intercept('POST', 'https://www.googleapis.com/upload/youtube/v3/videos*', (req) => {
       const body = typeof req.body === 'string' ? JSON.parse(req.body) : req.body;

--- a/electron/main.js
+++ b/electron/main.js
@@ -19,6 +19,7 @@ const GOOGLE_OAUTH_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
 const GOOGLE_OAUTH_TOKEN_URL = 'https://oauth2.googleapis.com/token';
 const YOUTUBE_UPLOAD_SCOPE = 'https://www.googleapis.com/auth/youtube.upload';
 const GOOGLE_CLIENT_ID_PATTERN = /^\d+-[a-z0-9_-]+\.apps\.googleusercontent\.com$/i;
+const YOUTUBE_AUTH_STORE_FILE = 'youtube-auth.json';
 let activeYouTubeOAuthCleanup = null;
 
 // Presentation window settings
@@ -116,6 +117,43 @@ function listenHttpServer(server, port, host) {
     server.once('listening', handleListening);
     server.listen(port, host);
   });
+}
+
+function getYouTubeAuthStorePath() {
+  return path.join(app.getPath('userData'), YOUTUBE_AUTH_STORE_FILE);
+}
+
+function readStoredYouTubeAuth() {
+  try {
+    const filePath = getYouTubeAuthStorePath();
+    if (!fs.existsSync(filePath)) {
+      return null;
+    }
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (error) {
+    console.warn('Failed to read stored YouTube authorization:', error);
+    return null;
+  }
+}
+
+function writeStoredYouTubeAuth(authState) {
+  try {
+    fs.mkdirSync(path.dirname(getYouTubeAuthStorePath()), { recursive: true });
+    fs.writeFileSync(getYouTubeAuthStorePath(), JSON.stringify(authState, null, 2));
+  } catch (error) {
+    console.warn('Failed to store YouTube authorization:', error);
+  }
+}
+
+function clearStoredYouTubeAuth() {
+  try {
+    const filePath = getYouTubeAuthStorePath();
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath);
+    }
+  } catch (error) {
+    console.warn('Failed to clear stored YouTube authorization:', error);
+  }
 }
 
 function listenAppServer(server, port) {
@@ -337,6 +375,56 @@ async function exchangeYouTubeOAuthCode({ clientId, clientSecret, code, redirect
   return {
     accessToken: details.access_token,
     expiresIn: Number(details.expires_in || 3600),
+    refreshToken: typeof details.refresh_token === 'string' ? details.refresh_token : '',
+    scope: typeof details.scope === 'string' ? details.scope : YOUTUBE_UPLOAD_SCOPE,
+  };
+}
+
+async function refreshYouTubeAccessToken(authState) {
+  if (!authState || !authState.clientId || !authState.refreshToken) {
+    throw new Error('Stored Google authorization is incomplete.');
+  }
+
+  const body = new URLSearchParams({
+    client_id: authState.clientId,
+    grant_type: 'refresh_token',
+    refresh_token: authState.refreshToken,
+  });
+
+  if (authState.clientSecret) {
+    body.set('client_secret', authState.clientSecret);
+  }
+
+  const response = await fetch(GOOGLE_OAUTH_TOKEN_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: body.toString(),
+  });
+  const text = await response.text();
+  let details = null;
+
+  if (text) {
+    try {
+      details = JSON.parse(text);
+    } catch {
+      details = { error_description: text };
+    }
+  }
+
+  if (!response.ok) {
+    clearStoredYouTubeAuth();
+    throw new Error(getOAuthTokenErrorMessage(details, response.status));
+  }
+
+  if (!details || typeof details.access_token !== 'string') {
+    throw new Error('Google token refresh did not return an access token.');
+  }
+
+  return {
+    accessToken: details.access_token,
+    expiresIn: Number(details.expires_in || 3600),
     scope: typeof details.scope === 'string' ? details.scope : YOUTUBE_UPLOAD_SCOPE,
   };
 }
@@ -347,6 +435,16 @@ async function authorizeYouTubeWithDesktopOAuth(clientId, clientSecret = '') {
 
   if (!GOOGLE_CLIENT_ID_PATTERN.test(trimmedClientId)) {
     throw new Error('Use a Google OAuth Client ID ending in .apps.googleusercontent.com.');
+  }
+
+  const storedAuth = readStoredYouTubeAuth();
+  if (
+    storedAuth &&
+    storedAuth.clientId === trimmedClientId &&
+    storedAuth.clientSecret === trimmedClientSecret &&
+    storedAuth.refreshToken
+  ) {
+    return refreshYouTubeAccessToken(storedAuth);
   }
 
   if (activeYouTubeOAuthCleanup) {
@@ -378,17 +476,29 @@ async function authorizeYouTubeWithDesktopOAuth(clientId, clientSecret = '') {
     authUrl.searchParams.set('state', state);
     authUrl.searchParams.set('code_challenge', codeChallenge);
     authUrl.searchParams.set('code_challenge_method', 'S256');
+    authUrl.searchParams.set('access_type', 'offline');
+    authUrl.searchParams.set('prompt', 'consent');
 
     await shell.openExternal(authUrl.toString());
     const code = await codeWaiter.promise;
 
-    return exchangeYouTubeOAuthCode({
+    const tokenResult = await exchangeYouTubeOAuthCode({
       clientId: trimmedClientId,
       clientSecret: trimmedClientSecret,
       code,
       redirectUri,
       codeVerifier,
     });
+
+    if (tokenResult.refreshToken) {
+      writeStoredYouTubeAuth({
+        clientId: trimmedClientId,
+        clientSecret: trimmedClientSecret,
+        refreshToken: tokenResult.refreshToken,
+      });
+    }
+
+    return tokenResult;
   } finally {
     if (codeWaiter) {
       codeWaiter.cancel();
@@ -641,6 +751,11 @@ ipcMain.handle('youtube-authorize', async (event, credentials) => {
     console.error('Error authorizing YouTube upload:', error);
     return { success: false, error: error.message };
   }
+});
+
+ipcMain.handle('youtube-clear-authorization', async () => {
+  clearStoredYouTubeAuth();
+  return { success: true };
 });
 
 ipcMain.handle('preset-choose-folder', async () => {

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -14,6 +14,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   authorizeYouTube: async (clientId, clientSecret) => {
     return ipcRenderer.invoke('youtube-authorize', { clientId, clientSecret });
   },
+  clearYouTubeAuthorization: async () => {
+    return ipcRenderer.invoke('youtube-clear-authorization');
+  },
   choosePresetFolder: async () => {
     return ipcRenderer.invoke('preset-choose-folder');
   },

--- a/examples/index.html
+++ b/examples/index.html
@@ -724,6 +724,14 @@
             <input type="password" id="youtubeClientSecret" autocomplete="off" spellcheck="false" aria-label="Google desktop OAuth client secret">
           </label>
         </div>
+        <div class="youtube-auth-settings">
+          <div>
+            <span class="youtube-auth-settings-title">Google account</span>
+            <span id="youtubeAuthSettingsStatus" class="youtube-auth-settings-status">Not signed in</span>
+          </div>
+          <button id="youtubeSignOutBtn" type="button" class="btn btn-secondary">Sign out</button>
+          <button id="youtubeSignInSettingsBtn" type="button" class="btn">Sign in</button>
+        </div>
         <p id="youtubeAuthStatus" class="youtube-modal-status" aria-live="polite"></p>
       </div>
       <div class="modal-footer">

--- a/examples/styles.css
+++ b/examples/styles.css
@@ -1277,6 +1277,30 @@ html {
   align-items: center;
 }
 
+.youtube-auth-settings {
+  align-items: center;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  display: flex;
+  gap: var(--spacing-sm);
+  justify-content: space-between;
+  margin-top: var(--spacing-md);
+  padding: var(--spacing-sm);
+}
+
+.youtube-auth-settings-title {
+  display: block;
+  font-weight: 600;
+}
+
+.youtube-auth-settings-status {
+  color: var(--color-text-secondary);
+  display: block;
+  font-size: 0.9rem;
+  margin-top: 2px;
+}
+
 .youtube-modal-status {
   min-height: 20px;
   margin-top: var(--spacing-sm);

--- a/examples/youtube-upload.js
+++ b/examples/youtube-upload.js
@@ -17,6 +17,7 @@
   }
 
   const CLIENT_ID_KEY = 'audio-recorder-youtube-client-id';
+  const TOKEN_STATE_KEY = 'audio-recorder-youtube-token-state';
   const TOKEN_EXPIRY_SKEW_MS = 60000;
   const LOCALHOST_EXAMPLE_ORIGIN = 'http://localhost:8080';
   const UNSUPPORTED_ORIGIN_MESSAGE = 'Google sign-in requires a localhost or HTTPS URL. Open the app with npm run serve or Electron, then use the localhost page.';
@@ -30,6 +31,9 @@
   const clientIdInput = document.getElementById('youtubeClientId');
   const clientSecretField = document.getElementById('youtubeClientSecretField');
   const clientSecretInput = document.getElementById('youtubeClientSecret');
+  const authSettingsStatus = document.getElementById('youtubeAuthSettingsStatus');
+  const signOutBtn = document.getElementById('youtubeSignOutBtn');
+  const signInSettingsBtn = document.getElementById('youtubeSignInSettingsBtn');
   const authStatus = document.getElementById('youtubeAuthStatus');
 
   const uploadModal = document.getElementById('youtubeUploadModal');
@@ -52,7 +56,7 @@
 
   const requiredElements = [
     authModal, closeAuthBtn, cancelAuthBtn, openGoogleCloudOAuthBtn, authorizeBtn,
-    clientIdInput, clientSecretField, clientSecretInput, authStatus,
+    clientIdInput, clientSecretField, clientSecretInput, authSettingsStatus, signOutBtn, signInSettingsBtn, authStatus,
     uploadModal, closeUploadBtn, uploadForm, titleInput, descriptionInput, tagsInput,
     categorySelect, privacySelect, shortCheckbox, madeForKidsCheckbox, syntheticMediaCheckbox,
     notifySubscribersCheckbox, progressBar, progressFill, uploadStatus, cancelUploadBtn,
@@ -72,6 +76,7 @@
   let activeUploadController = null;
 
   clientIdInput.value = localStorage.getItem(CLIENT_ID_KEY) || '';
+  restoreStoredTokenState();
 
   function showModal(modal) {
     modal.style.display = 'flex';
@@ -126,6 +131,54 @@
 
   function hasValidAccessToken() {
     return Boolean(accessToken) && Date.now() < accessTokenExpiresAt - TOKEN_EXPIRY_SKEW_MS;
+  }
+
+  function saveTokenState() {
+    try {
+      if (accessToken && accessTokenExpiresAt) {
+        localStorage.setItem(TOKEN_STATE_KEY, JSON.stringify({ accessToken, accessTokenExpiresAt }));
+      } else {
+        localStorage.removeItem(TOKEN_STATE_KEY);
+      }
+    } catch (error) {
+      console.warn('Failed to save YouTube token state:', error);
+    }
+    updateAuthSettingsStatus();
+  }
+
+  function restoreStoredTokenState() {
+    try {
+      const saved = localStorage.getItem(TOKEN_STATE_KEY);
+      if (!saved) {
+        return;
+      }
+      const state = JSON.parse(saved);
+      if (state && typeof state.accessToken === 'string' && Number.isFinite(Number(state.accessTokenExpiresAt))) {
+        accessToken = state.accessToken;
+        accessTokenExpiresAt = Number(state.accessTokenExpiresAt);
+      }
+    } catch (error) {
+      console.warn('Failed to load YouTube token state:', error);
+    }
+  }
+
+  function clearYouTubeAuth() {
+    accessToken = '';
+    accessTokenExpiresAt = 0;
+    saveTokenState();
+
+    if (isElectronYouTubeOAuthAvailable() && typeof window.electronAPI.clearYouTubeAuthorization === 'function') {
+      window.electronAPI.clearYouTubeAuthorization().catch((error) => {
+        console.warn('Failed to clear Electron YouTube authorization:', error);
+      });
+    }
+  }
+
+  function updateAuthSettingsStatus() {
+    const signedIn = hasValidAccessToken();
+    authSettingsStatus.textContent = signedIn ? 'Signed in' : 'Not signed in';
+    signOutBtn.style.display = signedIn ? '' : 'none';
+    signInSettingsBtn.style.display = signedIn ? 'none' : '';
   }
 
   function isSupportedGoogleSignInOrigin() {
@@ -230,6 +283,7 @@
 
   function openAuthModal() {
     updateAuthModeFields();
+    updateAuthSettingsStatus();
     authorizeBtn.textContent = 'Sign in with Google';
     showModal(authModal);
     clientIdInput.focus();
@@ -336,6 +390,7 @@
 
       accessToken = result.accessToken;
       accessTokenExpiresAt = Date.now() + Number(result.expiresIn || 3600) * 1000;
+      saveTokenState();
       return accessToken;
     }
 
@@ -370,6 +425,7 @@
 
           accessToken = response.access_token;
           accessTokenExpiresAt = Date.now() + Number(response.expires_in || 3600) * 1000;
+          saveTokenState();
           resolve(accessToken);
         },
       });
@@ -464,8 +520,7 @@
         updateAppStatus('YouTube upload cancelled', 'ready');
       } else {
         if (error.status === 401 || error.status === 403) {
-          accessToken = '';
-          accessTokenExpiresAt = 0;
+          clearYouTubeAuth();
         }
         setStatus(uploadStatus, error.message || 'YouTube upload failed.', 'error');
         updateAppStatus('YouTube upload failed', 'error');
@@ -492,6 +547,11 @@
   cancelAuthBtn.addEventListener('click', closeAuthModal);
   openGoogleCloudOAuthBtn.addEventListener('click', openGoogleCloudOAuthSetup);
   authorizeBtn.addEventListener('click', authorizeYouTube);
+  signOutBtn.addEventListener('click', () => {
+    clearYouTubeAuth();
+    setStatus(authStatus, 'Signed out of Google.');
+  });
+  signInSettingsBtn.addEventListener('click', authorizeYouTube);
 
   closeUploadBtn.addEventListener('click', closeUploadModal);
   cancelUploadBtn.addEventListener('click', () => {
@@ -502,6 +562,7 @@
     }
   });
   uploadForm.addEventListener('submit', submitUpload);
+  updateAuthSettingsStatus();
 
   [authModal, uploadModal].forEach((modal) => {
     modal.addEventListener('click', (event) => {


### PR DESCRIPTION
## Summary
- Persist YouTube Google access token state in the browser example so a valid session opens the upload form after restart instead of asking for sign-in again.
- Add Electron desktop OAuth refresh-token storage under app user data, refresh silently for matching credentials, and clear stored authorization on sign-out or invalid refresh.
- Move Google account sign-in/sign-out controls into the YouTube auth settings surface.

Fixes Jhon-Crow/audio-recorder-with-visualization#121

## Reproduction
1. Sign in to Google for YouTube upload.
2. Restart/reload the app.
3. Click `Upload to YouTube` on a recording.

Before this change, the app showed the Google sign-in/client-secret flow again. With a valid saved authorization, it opens the upload form directly.

## Tests
- `npm run typecheck`
- `npm test -- --runInBand`
- `npm run build`
- `git diff --check`

## Notes
- Added Cypress coverage for restoring saved authorization after restart and signing out from the Google account settings.
- Focused Cypress run could not complete locally because this environment refused connections to the local `http://localhost:8080` server even after starting static servers; the spec changes are included for CI validation.
