### PR TITLE
Fix YouTube upload form accidental close

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-06T18:46:27.948Z for PR creation at branch issue-123-7b0766771743 for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/123

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-06T18:46:27.948Z for PR creation at branch issue-123-7b0766771743 for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/123

--- a/cypress/e2e/youtube-upload-ui.cy.js
+++ b/cypress/e2e/youtube-upload-ui.cy.js
@@ -232,4 +232,42 @@ describe('YouTube Upload UI', () => {
       .find('a')
       .should('have.attr', 'href', 'https://www.youtube.com/watch?v=video-abc');
   });
+
+  it('keeps the upload form open when text selection ends outside the form', () => {
+    cy.visit('/examples/index.html', {
+      onBeforeLoad(win) {
+        win.google = {
+          accounts: {
+            oauth2: {
+              initTokenClient(config) {
+                return {
+                  requestAccessToken() {
+                    config.callback({
+                      access_token: 'test-token',
+                      expires_in: 3600,
+                      scope: 'https://www.googleapis.com/auth/youtube.upload',
+                    });
+                  },
+                };
+              },
+            },
+          },
+        };
+      },
+    });
+    cy.waitForVisualization();
+
+    addSyntheticRecording();
+    cy.contains('button', 'Upload to YouTube').click();
+    cy.get('#youtubeClientId').type('123-test-client-id.apps.googleusercontent.com');
+    cy.get('#authorizeYouTubeBtn').click();
+
+    cy.get('#youtubeUploadModal').should('be.visible');
+    cy.get('#youtubeDescription').type('Rendered from Cypress');
+    cy.get('#youtubeDescription').trigger('mousedown');
+    cy.get('#youtubeUploadModal').trigger('mouseup').click('topLeft');
+
+    cy.get('#youtubeUploadModal').should('be.visible');
+    cy.get('#youtubeDescription').should('have.value', 'Rendered from Cypress');
+  });
 });

--- a/examples/youtube-upload.js
+++ b/examples/youtube-upload.js
@@ -503,15 +503,9 @@
   });
   uploadForm.addEventListener('submit', submitUpload);
 
-  [authModal, uploadModal].forEach((modal) => {
-    modal.addEventListener('click', (event) => {
-      if (event.target === modal) {
-        if (modal === authModal) {
-          closeAuthModal();
-        } else {
-          closeUploadModal();
-        }
-      }
-    });
+  authModal.addEventListener('click', (event) => {
+    if (event.target === authModal) {
+      closeAuthModal();
+    }
   });
 })();


### PR DESCRIPTION
## Summary

Fixes Jhon-Crow/audio-recorder-with-visualization#123.

The YouTube upload form was closing from the modal backdrop click handler. When selecting text inside a field and releasing the pointer outside the form, the release/click could land on the backdrop and hide the upload modal. The upload modal now closes only through its explicit close/cancel controls or the upload flow, while the auth modal keeps its existing backdrop dismissal behavior.

## Reproduction / Verification

Reproduced with a Cypress flow that opens the YouTube upload form, types in the description field, starts a text-selection gesture in the field, and releases/clicks on the modal backdrop. The test asserts the form remains open and the typed text remains intact.

Automated coverage added:
- `cypress/e2e/youtube-upload-ui.cy.js` includes `keeps the upload form open when text selection ends outside the form`.

Local checks run:
- `npx cypress run --spec cypress/e2e/youtube-upload-ui.cy.js`
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

PR cleanup:
- Removed the auto-generated `.gitkeep` placeholder so the final diff only contains the upload modal fix and regression test.
