### PR TITLE
Remember YouTube upload form options

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-06T18:53:27.467Z for PR creation at branch issue-124-5e3f93d202b2 for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/124

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-06T18:53:27.467Z for PR creation at branch issue-124-5e3f93d202b2 for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/124

--- a/cypress/e2e/youtube-upload-ui.cy.js
+++ b/cypress/e2e/youtube-upload-ui.cy.js
@@ -232,4 +232,70 @@ describe('YouTube Upload UI', () => {
       .find('a')
       .should('have.attr', 'href', 'https://www.youtube.com/watch?v=video-abc');
   });
+
+  it('remembers upload tags and checkbox states from the last upload attempt', () => {
+    cy.intercept('POST', 'https://www.googleapis.com/upload/youtube/v3/videos*', {
+      statusCode: 200,
+      headers: { Location: 'https://upload.example/session' },
+      body: '',
+    }).as('startYouTubeUpload');
+
+    cy.intercept('PUT', 'https://upload.example/session', {
+      statusCode: 201,
+      body: { id: 'video-memory' },
+    }).as('finishYouTubeUpload');
+
+    cy.visit('/examples/index.html', {
+      onBeforeLoad(win) {
+        win.google = {
+          accounts: {
+            oauth2: {
+              initTokenClient(config) {
+                return {
+                  requestAccessToken() {
+                    config.callback({
+                      access_token: 'test-token',
+                      expires_in: 3600,
+                      scope: 'https://www.googleapis.com/auth/youtube.upload',
+                    });
+                  },
+                };
+              },
+            },
+          },
+        };
+      },
+    });
+    cy.waitForVisualization();
+
+    addSyntheticRecording();
+    cy.contains('button', 'Upload to YouTube').click();
+
+    cy.get('#youtubeClientId').type('123-test-client-id.apps.googleusercontent.com');
+    cy.get('#authorizeYouTubeBtn').click();
+
+    cy.get('#youtubeUploadModal').should('be.visible');
+    cy.get('#youtubeTags').clear().type('ambient, saved, cypress');
+    cy.get('#youtubeShort').check();
+    cy.get('#youtubeMadeForKids').check();
+    cy.get('#youtubeSyntheticMedia').check();
+    cy.get('#youtubeNotifySubscribers').check();
+    cy.get('#submitYouTubeUploadBtn').click();
+
+    cy.wait('@startYouTubeUpload');
+    cy.wait('@finishYouTubeUpload');
+    cy.get('#closeYouTubeUploadBtn').click();
+
+    addSyntheticRecording();
+    cy.contains('.recording-item', 'Recording 2').within(() => {
+      cy.contains('button', 'Upload to YouTube').click();
+    });
+
+    cy.get('#youtubeUploadModal').should('be.visible');
+    cy.get('#youtubeTags').should('have.value', 'ambient, saved, cypress');
+    cy.get('#youtubeShort').should('be.checked');
+    cy.get('#youtubeMadeForKids').should('be.checked');
+    cy.get('#youtubeSyntheticMedia').should('be.checked');
+    cy.get('#youtubeNotifySubscribers').should('be.checked');
+  });
 });

--- a/examples/youtube-upload.js
+++ b/examples/youtube-upload.js
@@ -17,6 +17,7 @@
   }
 
   const CLIENT_ID_KEY = 'audio-recorder-youtube-client-id';
+  const UPLOAD_FORM_STATE_KEY = 'audio-recorder-youtube-upload-form-state';
   const TOKEN_EXPIRY_SKEW_MS = 60000;
   const LOCALHOST_EXAMPLE_ORIGIN = 'http://localhost:8080';
   const UNSUPPORTED_ORIGIN_MESSAGE = 'Google sign-in requires a localhost or HTTPS URL. Open the app with npm run serve or Electron, then use the localhost page.';
@@ -214,6 +215,53 @@
     return dimensions.height > dimensions.width;
   }
 
+  function getDefaultUploadFormState() {
+    return {
+      description: '',
+      tags: 'audio, visualizer',
+      categoryId: '10',
+      privacyStatus: 'private',
+      short: shouldDefaultToShort(),
+      madeForKids: false,
+      syntheticMedia: false,
+      notifySubscribers: false,
+    };
+  }
+
+  function loadUploadFormState() {
+    const defaults = getDefaultUploadFormState();
+    const savedState = localStorage.getItem(UPLOAD_FORM_STATE_KEY);
+
+    if (!savedState) {
+      return defaults;
+    }
+
+    try {
+      const parsedState = JSON.parse(savedState);
+      return {
+        ...defaults,
+        ...parsedState,
+      };
+    } catch (error) {
+      return defaults;
+    }
+  }
+
+  function saveUploadFormState() {
+    const state = {
+      description: descriptionInput.value,
+      tags: tagsInput.value,
+      categoryId: categorySelect.value,
+      privacyStatus: privacySelect.value,
+      short: shortCheckbox.checked,
+      madeForKids: madeForKidsCheckbox.checked,
+      syntheticMedia: syntheticMediaCheckbox.checked,
+      notifySubscribers: notifySubscribersCheckbox.checked,
+    };
+
+    localStorage.setItem(UPLOAD_FORM_STATE_KEY, JSON.stringify(state));
+  }
+
   function resetProgress() {
     progressBar.style.display = 'none';
     progressBar.setAttribute('aria-valuenow', '0');
@@ -272,15 +320,17 @@
       return;
     }
 
+    const savedState = loadUploadFormState();
+
     titleInput.value = getDefaultTitle(pendingUpload.fileName);
-    descriptionInput.value = '';
-    tagsInput.value = 'audio, visualizer';
-    categorySelect.value = '10';
-    privacySelect.value = 'private';
-    shortCheckbox.checked = shouldDefaultToShort();
-    madeForKidsCheckbox.checked = false;
-    syntheticMediaCheckbox.checked = false;
-    notifySubscribersCheckbox.checked = false;
+    descriptionInput.value = savedState.description;
+    tagsInput.value = savedState.tags;
+    categorySelect.value = savedState.categoryId;
+    privacySelect.value = savedState.privacyStatus;
+    shortCheckbox.checked = savedState.short;
+    madeForKidsCheckbox.checked = savedState.madeForKids;
+    syntheticMediaCheckbox.checked = savedState.syntheticMedia;
+    notifySubscribersCheckbox.checked = savedState.notifySubscribers;
     submitUploadBtn.disabled = false;
     submitUploadBtn.textContent = 'Upload';
     cancelUploadBtn.textContent = 'Cancel';
@@ -440,6 +490,7 @@
       return;
     }
 
+    saveUploadFormState();
     activeUploadController = new AbortController();
     submitUploadBtn.disabled = true;
     submitUploadBtn.textContent = 'Uploading...';


### PR DESCRIPTION
## Summary

Fixes Jhon-Crow/audio-recorder-with-visualization#124.

The YouTube upload form now restores the tags and checkbox states from the last time the user pressed Upload:
- persists upload form options in localStorage when Upload is submitted
- restores saved tags, privacy/category selections, description, and checkbox states when the upload modal opens again
- keeps the existing generated title behavior per recording

## Reproduction / Verification

Before this change, reopening the YouTube upload form reset tags to the defaults and unchecked the upload option checkboxes.

Automated coverage added:
- `cypress/e2e/youtube-upload-ui.cy.js` now verifies that a completed upload attempt saves custom tags and all checkbox states, then restores them for the next recording upload form.

Local checks run:
- `npm test`
- `npm run build`
- `npx cypress run --spec cypress/e2e/youtube-upload-ui.cy.js`
