### PR TITLE
Add manual preset folder loading

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-07T02:21:00.078Z for PR creation at branch issue-132-ed1d0581cc9f for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/132

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-07T02:21:00.078Z for PR creation at branch issue-132-ed1d0581cc9f for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/132

--- a/cypress/e2e/preset-management.cy.js
+++ b/cypress/e2e/preset-management.cy.js
@@ -163,4 +163,75 @@ describe('Preset Management', () => {
       expect(win.localStorage.getItem('audio-recorder-active-preset-id')).to.equal(null);
     });
   });
+
+  it('loads presets from a manually selected Electron folder', () => {
+    cy.window().then((win) => {
+      win.electronAPI = {
+        choosePresetFolder: () => Promise.resolve({ success: true, folderPath: '/old/presets' }),
+        loadPresetFiles: () => Promise.resolve({
+          success: true,
+          presets: [
+            {
+              id: 'legacy-preset',
+              name: 'Legacy',
+              createdAt: '2026-06-01T00:00:00.000Z',
+              settings: { visualizer: 'waveform', primaryColor: '#ff0000' },
+            },
+          ],
+        }),
+      };
+      cy.spy(win.electronAPI, 'choosePresetFolder').as('choosePresetFolder');
+      cy.spy(win.electronAPI, 'loadPresetFiles').as('loadPresetFiles');
+    });
+
+    cy.get('#presetEdgeTrigger').trigger('pointerenter');
+    cy.get('#presetSettingsBtn').click();
+    cy.get('#presetSettingsChooseFolderBtn').click();
+
+    cy.get('@choosePresetFolder').should('have.been.calledOnce');
+    cy.get('@loadPresetFiles').should('have.been.calledWith', '/old/presets');
+    cy.get('#presetSettingsPathInput').should('have.value', '/old/presets');
+    cy.get('#presetList .preset-load-btn').should('have.length', 1).first().should('contain', 'Legacy');
+
+    cy.get('#presetSettingsCloseBtn').click();
+    cy.get('#presetEdgeTrigger').trigger('pointerenter');
+    cy.get('#presetList .preset-load-btn').first().click();
+    cy.get('#visualizerSelect').should('have.value', 'waveform');
+    cy.get('#primaryColor').should('have.value', '#ff0000');
+
+    cy.window().then((win) => {
+      const presets = JSON.parse(win.localStorage.getItem('audio-recorder-presets'));
+      expect(presets).to.have.length(1);
+      expect(presets[0].id).to.equal('legacy-preset');
+
+      const options = JSON.parse(win.localStorage.getItem('audio-recorder-preset-options'));
+      expect(options.savePath).to.equal('/old/presets');
+    });
+  });
+
+  it('loads presets from a saved Electron folder on startup', () => {
+    cy.window().then((win) => {
+      win.localStorage.setItem('audio-recorder-preset-options', JSON.stringify({
+        savePath: '/old/presets',
+        skipDialog: false,
+      }));
+      win.electronAPI = {
+        loadPresetFiles: () => Promise.resolve({
+          success: true,
+          presets: [
+            {
+              id: 'startup-legacy-preset',
+              name: 'Startup Legacy',
+              createdAt: '2026-06-01T00:00:00.000Z',
+              settings: { visualizer: 'waveform', primaryColor: '#ff0000' },
+            },
+          ],
+        }),
+      };
+      return win.AudioRecorderApp.loadPresetsFromFolder('/old/presets');
+    });
+
+    cy.get('#presetEdgeTrigger').trigger('pointerenter');
+    cy.get('#presetList .preset-load-btn').should('have.length', 1).first().should('contain', 'Startup Legacy');
+  });
 });

--- a/electron/main.js
+++ b/electron/main.js
@@ -826,6 +826,44 @@ ipcMain.handle('preset-save-file', async (event, folderPath, preset) => {
   }
 });
 
+ipcMain.handle('preset-load-files', async (event, folderPath) => {
+  try {
+    if (!folderPath) {
+      return { success: false, error: 'Preset folder is not configured' };
+    }
+
+    if (!fs.existsSync(folderPath)) {
+      return { success: true, presets: [] };
+    }
+
+    const stat = fs.statSync(folderPath);
+    if (!stat.isDirectory()) {
+      return { success: false, error: 'Preset path is not a folder' };
+    }
+
+    const presets = fs.readdirSync(folderPath)
+      .filter(fileName => path.extname(fileName).toLowerCase() === '.json')
+      .map(fileName => {
+        const filePath = path.join(folderPath, fileName);
+        try {
+          const preset = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+          return preset && typeof preset === 'object'
+            ? { ...preset, sourcePath: filePath }
+            : null;
+        } catch (error) {
+          console.warn(`Failed to read preset file ${filePath}:`, error);
+          return null;
+        }
+      })
+      .filter(Boolean);
+
+    return { success: true, presets };
+  } catch (error) {
+    console.error('Error loading preset files:', error);
+    return { success: false, error: error.message };
+  }
+});
+
 // ==================== PRESENTATION MODE IPC HANDLERS ====================
 
 // Start/toggle presentation mode

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -33,6 +33,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   savePresetFile: async (folderPath, preset) => {
     return ipcRenderer.invoke('preset-save-file', folderPath, preset);
   },
+  loadPresetFiles: async (folderPath) => {
+    return ipcRenderer.invoke('preset-load-files', folderPath);
+  },
   isElectron: true,
 
   // ==================== PRESENTATION MODE APIs ====================

--- a/examples/app-core.js
+++ b/examples/app-core.js
@@ -312,6 +312,69 @@ window.AudioRecorderApp = window.AudioRecorderApp || {};
     }
   }
 
+  function normalizeFolderPreset(preset, index = 0) {
+    if (!preset || typeof preset !== 'object' || !preset.settings || typeof preset.settings !== 'object') {
+      return null;
+    }
+
+    const id = preset.id || preset.sourcePath || `folder-preset-${index}`;
+    return {
+      ...preset,
+      id: String(id),
+      name: preset.name ? String(preset.name) : String(index + 1),
+      createdAt: preset.createdAt || new Date().toISOString(),
+      settings: preset.settings,
+    };
+  }
+
+  function mergePresets(nextPresets) {
+    const normalized = nextPresets
+      .map(normalizeFolderPreset)
+      .filter(Boolean);
+
+    if (!normalized.length) {
+      return 0;
+    }
+
+    const existingIds = new Set(presets.map(preset => preset.id));
+    const additions = normalized.filter(preset => !existingIds.has(preset.id));
+    if (!additions.length) {
+      return 0;
+    }
+
+    presets = [...presets, ...additions];
+    savePresets(presets);
+    renderPresets();
+    return additions.length;
+  }
+
+  async function loadPresetsFromFolder(folderPath, { notify = false } = {}) {
+    if (!window.electronAPI || !window.electronAPI.loadPresetFiles || !folderPath || folderPath === 'Browser local storage') {
+      return 0;
+    }
+
+    const result = await window.electronAPI.loadPresetFiles(folderPath);
+    if (!result || !result.success) {
+      const error = result && result.error ? result.error : 'Unknown error';
+      console.warn('Failed to load preset files:', error);
+      if (notify) {
+        updateStatus(`Could not load presets: ${error}`, 'error');
+      }
+      return 0;
+    }
+
+    const addedCount = mergePresets(result.presets || []);
+    if (notify) {
+      updateStatus(
+        addedCount > 0
+          ? `Loaded ${addedCount} preset${addedCount === 1 ? '' : 's'} from folder`
+          : 'No new presets found in folder',
+        'ready'
+      );
+    }
+    return addedCount;
+  }
+
   function loadPresetOptions() {
     try {
       const saved = localStorage.getItem(PRESET_OPTIONS_KEY);
@@ -1541,6 +1604,7 @@ window.AudioRecorderApp = window.AudioRecorderApp || {};
         savePresetOptions(presetOptions);
         presetFolderInput.value = result.folderPath;
         presetSettingsPathInput.value = result.folderPath;
+        await loadPresetsFromFolder(result.folderPath, { notify: true });
       }
       return;
     }
@@ -1663,6 +1727,7 @@ window.AudioRecorderApp = window.AudioRecorderApp || {};
   function initializePresetControls() {
     presetSettingsPathInput.value = presetOptions.savePath || 'Browser local storage';
     renderPresets();
+    loadPresetsFromFolder(presetOptions.savePath);
 
     savePresetBtn.addEventListener('click', async () => {
       if (presetOptions.skipDialog) {
@@ -1835,6 +1900,8 @@ window.AudioRecorderApp = window.AudioRecorderApp || {};
     addRecording,
     getVideoDimensions,
     applyVideoDimensions,
+    loadPresetsFromFolder,
+    choosePresetFolder,
     // Elements (for other modules)
     elements: {
       visualizerSelect,


### PR DESCRIPTION
## Summary
- Adds Electron IPC/preload support for reading preset JSON files from a selected folder.
- Imports and merges presets from the chosen folder into the sidebar without duplicating existing preset IDs.
- Reloads presets from the saved folder path on startup so presets from previous app versions become visible again.
- Adds Cypress coverage for selecting a legacy preset folder and loading presets from a saved folder path.

Fixes Jhon-Crow/audio-recorder-with-visualization#132

## Verification
- npm test -- --runInBand
- npm run build
- npm run test:e2e -- --spec cypress/e2e/preset-management.cy.js