### PR TITLE
Add playlist selection to YouTube upload form

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-07T03:09:06.554Z for PR creation at branch issue-134-c15c17fb52f3 for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/134

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-07T03:09:06.554Z for PR creation at branch issue-134-c15c17fb52f3 for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/134

--- a/cypress/e2e/youtube-upload-ui.cy.js
+++ b/cypress/e2e/youtube-upload-ui.cy.js
@@ -15,7 +15,7 @@ describe('YouTube Upload UI', () => {
 
     addSyntheticRecording();
 
-    cy.contains('.recording-item', 'Recording 1').within(() => {
+    cy.get('.recording-item').first().within(() => {
       cy.contains('a', 'Download').should('be.visible');
       cy.contains('button', 'Upload to YouTube').should('be.visible').click();
     });
@@ -257,6 +257,22 @@ describe('YouTube Upload UI', () => {
       });
     }).as('setYouTubeThumbnail');
 
+    cy.intercept('POST', 'https://www.googleapis.com/youtube/v3/playlistItems?part=snippet', (req) => {
+      const body = typeof req.body === 'string' ? JSON.parse(req.body) : req.body;
+
+      expect(req.headers.authorization).to.equal('Bearer test-token');
+      expect(body.snippet.playlistId).to.equal('PL-cypress');
+      expect(body.snippet.resourceId).to.deep.equal({
+        kind: 'youtube#video',
+        videoId: 'video-abc',
+      });
+
+      req.reply({
+        statusCode: 200,
+        body: { id: 'playlist-item-abc' },
+      });
+    }).as('addYouTubePlaylistItem');
+
     cy.visit('/examples/index.html', {
       onBeforeLoad(win) {
         win.google = {
@@ -291,6 +307,7 @@ describe('YouTube Upload UI', () => {
     cy.get('#youtubeTitle').clear().type('Published visualizer');
     cy.get('#youtubeDescription').type('Rendered from Cypress');
     cy.get('#youtubeTags').clear().type('audio, visualizer, cypress');
+    cy.get('#youtubePlaylistId').should('be.visible').type('PL-cypress');
     cy.get('#youtubeThumbnail').selectFile({
       contents: Cypress.Buffer.from('preview-image'),
       fileName: 'preview.png',
@@ -305,6 +322,7 @@ describe('YouTube Upload UI', () => {
     cy.wait('@startYouTubeUpload');
     cy.wait('@finishYouTubeUpload');
     cy.wait('@setYouTubeThumbnail');
+    cy.wait('@addYouTubePlaylistItem');
     cy.get('#youtubeUploadStatus')
       .should('contain.text', 'Uploaded:')
       .find('a')

--- a/examples/index.html
+++ b/examples/index.html
@@ -792,6 +792,10 @@
               <input type="text" id="youtubeTags" aria-label="YouTube video tags">
             </label>
             <label class="youtube-wide-field">
+              Playlist ID
+              <input type="text" id="youtubePlaylistId" aria-label="YouTube playlist ID">
+            </label>
+            <label class="youtube-wide-field">
               Video Preview
               <input type="file" id="youtubeThumbnail" accept="image/jpeg,image/png,image/webp" aria-label="YouTube video preview image">
             </label>

--- a/examples/youtube-upload.js
+++ b/examples/youtube-upload.js
@@ -42,6 +42,7 @@
   const titleInput = document.getElementById('youtubeTitle');
   const descriptionInput = document.getElementById('youtubeDescription');
   const tagsInput = document.getElementById('youtubeTags');
+  const playlistIdInput = document.getElementById('youtubePlaylistId');
   const thumbnailInput = document.getElementById('youtubeThumbnail');
   const categorySelect = document.getElementById('youtubeCategory');
   const privacySelect = document.getElementById('youtubePrivacy');
@@ -60,7 +61,7 @@
     authModal, closeAuthBtn, cancelAuthBtn, openGoogleCloudOAuthBtn, authorizeBtn,
     clientIdInput, clientSecretField, clientSecretInput, authSettingsStatus, signOutBtn, signInSettingsBtn, authStatus,
     uploadModal, closeUploadBtn, uploadForm, titleInput, descriptionInput, tagsInput, thumbnailInput,
-    categorySelect, privacySelect, publishAtInput, shortCheckbox, madeForKidsCheckbox, syntheticMediaCheckbox,
+    playlistIdInput, categorySelect, privacySelect, publishAtInput, shortCheckbox, madeForKidsCheckbox, syntheticMediaCheckbox,
     notifySubscribersCheckbox, progressBar, progressFill, uploadStatus, cancelUploadBtn,
     submitUploadBtn,
   ];
@@ -357,6 +358,7 @@
     titleInput.value = getDefaultTitle(pendingUpload.fileName);
     descriptionInput.value = '';
     tagsInput.value = 'audio, visualizer';
+    playlistIdInput.value = '';
     thumbnailInput.value = '';
     categorySelect.value = '10';
     privacySelect.value = 'private';
@@ -506,6 +508,7 @@
       title: titleInput.value,
       description: descriptionInput.value,
       tags: tagsInput.value,
+      playlistId: playlistIdInput.value,
       categoryId: categorySelect.value,
       privacyStatus: privacySelect.value,
       publishAt: getScheduledPublishAt(),

--- a/src/core/YouTubeUploader.ts
+++ b/src/core/YouTubeUploader.ts
@@ -5,6 +5,7 @@
 export const YOUTUBE_UPLOAD_SCOPE = 'https://www.googleapis.com/auth/youtube.upload';
 export const YOUTUBE_UPLOAD_ENDPOINT = 'https://www.googleapis.com/upload/youtube/v3/videos';
 export const YOUTUBE_THUMBNAIL_UPLOAD_ENDPOINT = 'https://www.googleapis.com/upload/youtube/v3/thumbnails/set';
+export const YOUTUBE_PLAYLIST_ITEMS_ENDPOINT = 'https://www.googleapis.com/youtube/v3/playlistItems';
 export const YOUTUBE_SHORT_HASHTAG = '#shorts';
 
 const DEFAULT_CATEGORY_ID = '10';
@@ -24,6 +25,7 @@ export interface YouTubeUploadMetadata {
   containsSyntheticMedia?: boolean;
   publishAt?: string | Date;
   short?: boolean;
+  playlistId?: string;
 }
 
 export interface YouTubeUploadProgress {
@@ -48,6 +50,7 @@ export interface YouTubeUploadResult {
   id: string;
   url: string;
   thumbnail?: unknown;
+  playlistItem?: unknown;
   rawResponse: unknown;
 }
 
@@ -72,6 +75,7 @@ export interface YouTubeUploaderConfig {
   fetch?: FetchLike;
   uploadEndpoint?: string;
   thumbnailUploadEndpoint?: string;
+  playlistItemsEndpoint?: string;
 }
 
 export class YouTubeUploadError extends Error {
@@ -181,11 +185,13 @@ export class YouTubeUploader {
   private readonly fetchImpl?: FetchLike;
   private readonly uploadEndpoint: string;
   private readonly thumbnailUploadEndpoint: string;
+  private readonly playlistItemsEndpoint: string;
 
   constructor(config: YouTubeUploaderConfig = {}) {
     this.fetchImpl = config.fetch;
     this.uploadEndpoint = config.uploadEndpoint || YOUTUBE_UPLOAD_ENDPOINT;
     this.thumbnailUploadEndpoint = config.thumbnailUploadEndpoint || YOUTUBE_THUMBNAIL_UPLOAD_ENDPOINT;
+    this.playlistItemsEndpoint = config.playlistItemsEndpoint || YOUTUBE_PLAYLIST_ITEMS_ENDPOINT;
   }
 
   async upload(request: YouTubeUploadRequest): Promise<YouTubeUploadResult> {
@@ -225,6 +231,17 @@ export class YouTubeUploader {
         request.accessToken,
         result.id,
         request.thumbnail,
+        request.signal
+      );
+    }
+
+    const playlistId = request.metadata.playlistId?.trim();
+    if (playlistId) {
+      result.playlistItem = await this.addVideoToPlaylist(
+        fetchImpl,
+        request.accessToken,
+        playlistId,
+        result.id,
         request.signal
       );
     }
@@ -366,6 +383,41 @@ export class YouTubeUploader {
 
     if (!response.ok) {
       throw await this.createError(response, 'Unable to set YouTube video thumbnail');
+    }
+
+    return readResponseBody(response);
+  }
+
+  private async addVideoToPlaylist(
+    fetchImpl: FetchLike,
+    accessToken: string,
+    playlistId: string,
+    videoId: string,
+    signal?: AbortSignal
+  ): Promise<unknown> {
+    const url = new URL(this.playlistItemsEndpoint);
+    url.searchParams.set('part', 'snippet');
+
+    const response = await fetchImpl(url.toString(), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json; charset=UTF-8',
+      },
+      body: JSON.stringify({
+        snippet: {
+          playlistId,
+          resourceId: {
+            kind: 'youtube#video',
+            videoId,
+          },
+        },
+      }),
+      signal,
+    });
+
+    if (!response.ok) {
+      throw await this.createError(response, 'Unable to add YouTube video to playlist');
     }
 
     return readResponseBody(response);

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export {
   buildYouTubeVideoResource,
   getYouTubeWatchUrl,
   normalizeYouTubeTags,
+  YOUTUBE_PLAYLIST_ITEMS_ENDPOINT,
   YOUTUBE_SHORT_HASHTAG,
   YOUTUBE_UPLOAD_ENDPOINT,
   YOUTUBE_UPLOAD_SCOPE,

--- a/tests/YouTubeUploader.test.ts
+++ b/tests/YouTubeUploader.test.ts
@@ -201,6 +201,53 @@ describe('YouTubeUploader', () => {
       expect(thumbnailInit.body).toBe(thumbnail);
     });
 
+    test('adds the uploaded video to the requested playlist', async () => {
+      const fetchMock = createFetchMock();
+      fetchMock
+        .mockResolvedValueOnce(createResponse(null, {
+          status: 200,
+          headers: { Location: 'https://upload.example/session' },
+        }))
+        .mockResolvedValueOnce(createResponse(JSON.stringify({ id: 'video-123' }), {
+          status: 201,
+        }))
+        .mockResolvedValueOnce(createResponse(JSON.stringify({ id: 'playlist-item-123' }), {
+          status: 200,
+        }));
+
+      const uploader = new YouTubeUploader({ fetch: fetchMock });
+      const result = await uploader.upload({
+        video: new Blob(['video'], { type: 'video/webm' }),
+        accessToken: 'token-123',
+        metadata: {
+          title: 'Audio visualizer',
+          playlistId: ' PL123 ',
+        },
+      });
+
+      expect(result.playlistItem).toEqual({ id: 'playlist-item-123' });
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(String(fetchMock.mock.calls[2][0])).toBe(
+        'https://www.googleapis.com/youtube/v3/playlistItems?part=snippet',
+      );
+
+      const playlistInit = fetchMock.mock.calls[2][1] as RequestInit;
+      expect(playlistInit.method).toBe('POST');
+      expect(playlistInit.headers).toMatchObject({
+        Authorization: 'Bearer token-123',
+        'Content-Type': 'application/json; charset=UTF-8',
+      });
+      expect(JSON.parse(playlistInit.body as string)).toEqual({
+        snippet: {
+          playlistId: 'PL123',
+          resourceId: {
+            kind: 'youtube#video',
+            videoId: 'video-123',
+          },
+        },
+      });
+    });
+
     test('continues after a 308 resumable response', async () => {
       const fetchMock = createFetchMock();
       fetchMock


### PR DESCRIPTION
## Summary
- Adds a Playlist ID field to the YouTube upload modal so uploaded videos can be placed into a chosen playlist.
- Extends `YouTubeUploader` to call `playlistItems.insert` after the video upload succeeds when `metadata.playlistId` is provided.
- Keeps playlist insertion configurable through `playlistItemsEndpoint` and returns the playlist item response on the upload result.

## Reproduce
1. Open the example app and add a recording.
2. Click `Upload to YouTube`.
3. The existing upload form did not offer any playlist destination field.

## Verification
- `npm test -- --runTestsByPath tests/YouTubeUploader.test.ts`
- `npm run typecheck`
- `npm run build`
- `npx cypress run --spec cypress/e2e/youtube-upload-ui.cy.js` with a root `http-server` on port 8080
- `npm test`

Fixes Jhon-Crow/audio-recorder-with-visualization#134
