### PR TITLE
Fix pipeline stage navigation widget layout

### DIFF
--- a/.github/workflows/build-portable.yml
+++ b/.github/workflows/build-portable.yml
@@ -29,6 +29,16 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Cache electron-builder binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~\AppData\Local\electron-builder\Cache
+            ~\AppData\Local\electron\Cache
+          key: electron-builder-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            electron-builder-${{ runner.os }}-
+
       - name: Run tests
         run: npm test
 
@@ -36,7 +46,19 @@ jobs:
         run: npm run build
 
       - name: Build portable EXE
-        run: npm run electron:build
+        shell: pwsh
+        run: |
+          for ($attempt = 1; $attempt -le 3; $attempt++) {
+            npm run electron:build
+            if ($LASTEXITCODE -eq 0) {
+              exit 0
+            }
+
+            Write-Host "electron-builder attempt $attempt failed with exit code $LASTEXITCODE"
+            Start-Sleep -Seconds (15 * $attempt)
+          }
+
+          exit $LASTEXITCODE
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-08T06:50:52.272Z for PR creation at branch issue-146-73c5e777ff09 for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/146

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-08T06:50:52.272Z for PR creation at branch issue-146-73c5e777ff09 for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/146

--- a/cypress/e2e/pipeline-mode.cy.js
+++ b/cypress/e2e/pipeline-mode.cy.js
@@ -131,6 +131,14 @@ describe('Pipeline Mode', () => {
       expect(rect.height).to.be.lessThan(260);
       expect(rect.bottom).to.be.closeTo(Cypress.config('viewportHeight') - bottomOffset, 4);
     });
+    cy.get('#pipelineStageNav').then(($nav) => {
+      cy.get('#pipelineSidebar').then(($sidebar) => {
+        const navRect = $nav[0].getBoundingClientRect();
+        const sidebarRect = $sidebar[0].getBoundingClientRect();
+        expect(navRect.right).to.be.lessThan(sidebarRect.left + 1);
+        expect(sidebarRect.left - navRect.right).to.be.lessThan(72);
+      });
+    });
     cy.get('.pipeline-workspace').then(($workspace) => {
       expect($workspace.css('display')).to.eq('block');
     });
@@ -149,6 +157,10 @@ describe('Pipeline Mode', () => {
       .and('contain.text', 'Visualization + update')
       .invoke('text')
       .should('match', /\d{4}-\d{2}-\d{2}/);
+    cy.get('#pipelineStageNav .pipeline-stage-nav-btn').eq(1).find('.pipeline-stage-nav-meta').then(($meta) => {
+      const meta = $meta[0];
+      expect(meta.scrollWidth).to.be.at.most(meta.clientWidth + 1);
+    });
 
     cy.get('.pipeline-stage').eq(2).then(($stage) => {
       const stageId = $stage.attr('data-stage-id');

--- a/examples/styles.css
+++ b/examples/styles.css
@@ -133,10 +133,10 @@ body {
 .pipeline-stage-nav {
   position: fixed;
   top: auto;
-  right: calc(300px + var(--spacing-lg));
+  right: calc(64px + var(--spacing-lg));
   bottom: var(--spacing-lg);
   z-index: 245;
-  width: 248px;
+  width: min(360px, calc(100vw - 64px - (var(--spacing-lg) * 3)));
   max-height: calc(100vh - (var(--spacing-lg) * 2));
   display: flex;
   flex-direction: column;
@@ -227,7 +227,7 @@ body {
   font-size: 11px;
   line-height: 1.25;
   text-overflow: ellipsis;
-  white-space: nowrap;
+  white-space: normal;
 }
 
 .preset-list {


### PR DESCRIPTION
## Summary

Fixes Jhon-Crow/audio-recorder-with-visualization#146.

- Moves the fixed pipeline stage navigator next to the actual right pipeline sidebar instead of using the stale wide-sidebar offset.
- Widens the stage navigator responsively so release dates have enough room.
- Lets stage metadata wrap instead of clipping date text inside nav items.
- Adds Cypress assertions that the navigator does not overlap the right sidebar and that the release date metadata is not horizontally clipped.
- Hardens the Windows portable build workflow by caching Electron/electron-builder binaries and retrying the packaging command after transient binary download failures.

## CI failure investigation

The failing upstream check was `Build Portable EXE / build` on commit `84d2632d95aaa79e875bbecaea95eae9cfac3f63`. Unit tests and the library build passed in CI; the failure happened during `npm run electron:build` when electron-builder tried to fetch NSIS:

`cannot resolve https://github.com/electron-userland/electron-builder-binaries/releases/download/nsis-3.0.4.1/nsis-3.0.4.1.7z: status code 504`

The log is preserved locally in `ci-logs/build-27121251056.log`.

## Verification

- `npm test -- --runInBand`
- `npm run typecheck`
- `npm run build`
- `CYPRESS_BASE_URL=http://localhost:8091 npm run test:e2e -- --spec cypress/e2e/pipeline-mode.cy.js`

Fixes Jhon-Crow/audio-recorder-with-visualization#146
