### PR TITLE
Keep Electron YouTube authorization across restarts

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-18T06:01:19.219Z for PR creation at branch issue-153-c467b77ef84b for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/153

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-18T06:01:19.219Z for PR creation at branch issue-153-c467b77ef84b for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/153

--- a/cypress/e2e/youtube-upload-ui.cy.js
+++ b/cypress/e2e/youtube-upload-ui.cy.js
@@ -170,6 +170,33 @@ describe('YouTube Upload UI', () => {
     cy.get('#youtubeUploadModal').should('be.visible');
   });
 
+  it('restores Electron Google authorization with the saved client ID before showing the auth form', () => {
+    cy.visit('/examples/index.html', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('audio-recorder-youtube-client-id', '123-desktop-client-id.apps.googleusercontent.com');
+        win.electronAPI = {
+          isElectron: true,
+          authorizeYouTube: cy.stub().as('authorizeYouTube').resolves({
+            accessToken: 'refreshed-electron-token',
+            expiresIn: 3600,
+            scope: combinedYouTubeScope,
+          }),
+        };
+      },
+    });
+    cy.waitForVisualization();
+
+    addSyntheticRecording();
+    cy.contains('button', 'Upload to YouTube').click();
+
+    cy.get('@authorizeYouTube')
+      .should('have.been.calledOnce')
+      .and('have.been.calledWith', '123-desktop-client-id.apps.googleusercontent.com');
+    cy.get('#youtubeUploadModal').should('be.visible');
+    cy.get('#youtubeAuthModal').should('not.be.visible');
+    cy.get('#youtubeAuthSettingsStatus').should('contain.text', 'Signed in');
+  });
+
   it('restores saved Google authorization after a restart', () => {
     const futureExpiry = Date.now() + 3600 * 1000;
 

--- a/examples/youtube-upload.js
+++ b/examples/youtube-upload.js
@@ -345,6 +345,25 @@
     return Boolean(accessToken) && Date.now() < accessTokenExpiresAt - TOKEN_EXPIRY_SKEW_MS;
   }
 
+  async function restoreElectronYouTubeAuthorization() {
+    if (hasValidAccessToken() || !isElectronYouTubeOAuthAvailable()) {
+      return hasValidAccessToken();
+    }
+
+    const savedClientId = clientIdInput.value.trim();
+    if (!GOOGLE_CLIENT_ID_PATTERN.test(savedClientId)) {
+      return false;
+    }
+
+    try {
+      await requestAccessToken(savedClientId);
+      return hasValidAccessToken();
+    } catch (error) {
+      console.warn('Failed to restore stored Electron YouTube authorization:', error);
+      return false;
+    }
+  }
+
   function getRequiredYouTubeScope() {
     return YOUTUBE_UPLOAD_AND_PLAYLIST_SCOPE || YOUTUBE_UPLOAD_SCOPE;
   }
@@ -931,7 +950,14 @@
     if (hasValidAccessToken()) {
       openUploadModal();
     } else {
-      openAuthModal();
+      restoreElectronYouTubeAuthorization()
+        .then((restored) => {
+          if (restored) {
+            openUploadModal();
+          } else {
+            openAuthModal();
+          }
+        });
     }
   });
 


### PR DESCRIPTION
## Summary
- Restore Electron YouTube authorization from the saved Desktop OAuth client ID before showing the auth form.
- Reuse Electron's persisted refresh token path so users do not have to re-enter the Google client secret after restarting the app.
- Add a Cypress regression test for the restart flow with a saved client ID and no in-memory access token.

Fixes Jhon-Crow/audio-recorder-with-visualization#153

## Reproduction
1. Sign in to YouTube from the Electron app with a Desktop OAuth client ID and secret.
2. Restart the app after the short-lived renderer access token is gone.
3. Click Upload to YouTube on a recording.

Before this change, the Google authorization form appeared again. After this change, Electron refreshes the stored authorization and opens the upload form.

## Tests
- npm run build
- npx cypress run --spec cypress/e2e/youtube-upload-ui.cy.js
- npm run typecheck
- npm test -- --runInBand