### PR TITLE
Add timezone selector for single YouTube uploads

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-21T04:02:57.118Z for PR creation at branch issue-149-47289dc2cb1c for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/149

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-21T04:02:57.118Z for PR creation at branch issue-149-47289dc2cb1c for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/149

--- a/cypress/e2e/youtube-upload-ui.cy.js
+++ b/cypress/e2e/youtube-upload-ui.cy.js
@@ -564,6 +564,105 @@ describe('YouTube Upload UI', () => {
     cy.get('#youtubeNotifySubscribers').should('be.checked');
   });
 
+  it('shows a timezone selector in the upload modal', () => {
+    const futureExpiry = Date.now() + 3600 * 1000;
+
+    cy.visit('/examples/index.html', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('audio-recorder-youtube-token-state', JSON.stringify({
+          accessToken: 'stored-token',
+          accessTokenExpiresAt: futureExpiry,
+        }));
+      },
+    });
+    cy.waitForVisualization();
+
+    addSyntheticRecording();
+    cy.contains('button', 'Upload to YouTube').click();
+
+    cy.get('#youtubeUploadModal').should('be.visible');
+    cy.get('#youtubeTimezone').should('exist').and('be.visible');
+    cy.get('#youtubeTimezone option[value=""]').should('contain.text', 'Browser timezone');
+    cy.get('#youtubeTimezone option[value="UTC"]').should('exist');
+    cy.get('#youtubeTimezone option[value="Europe/Moscow"]').should('exist');
+  });
+
+  it('uses the selected timezone when computing the scheduled publish time', () => {
+    cy.intercept('POST', 'https://www.googleapis.com/upload/youtube/v3/videos*', (req) => {
+      const body = typeof req.body === 'string' ? JSON.parse(req.body) : req.body;
+      // Europe/Moscow is UTC+3, so 15:30 local = 12:30 UTC
+      expect(body.status.publishAt).to.equal('2026-07-01T12:30:00.000Z');
+
+      req.reply({
+        statusCode: 200,
+        headers: { Location: 'https://upload.example/tz-session' },
+        body: '',
+      });
+    }).as('startTimezoneUpload');
+
+    cy.intercept('PUT', 'https://upload.example/tz-session', {
+      statusCode: 201,
+      body: { id: 'video-tz' },
+    }).as('finishTimezoneUpload');
+
+    cy.visit('/examples/index.html', {
+      onBeforeLoad(win) {
+        win.google = {
+          accounts: {
+            oauth2: {
+              initTokenClient(config) {
+                return {
+                  requestAccessToken() {
+                    config.callback({
+                      access_token: 'test-token',
+                      expires_in: 3600,
+                      scope: combinedYouTubeScope,
+                    });
+                  },
+                };
+              },
+            },
+          },
+        };
+      },
+    });
+    cy.waitForVisualization();
+
+    addSyntheticRecording();
+    cy.contains('button', 'Upload to YouTube').click();
+    cy.get('#youtubeClientId').type('123-test-client-id.apps.googleusercontent.com');
+    cy.get('#authorizeYouTubeBtn').click();
+
+    cy.get('#youtubeUploadModal').should('be.visible');
+    cy.get('#youtubeTimezone').select('Europe/Moscow');
+    cy.get('#youtubePublishAt').type('2026-07-01T15:30');
+    cy.get('#submitYouTubeUploadBtn').click();
+
+    cy.wait('@startTimezoneUpload');
+    cy.wait('@finishTimezoneUpload');
+  });
+
+  it('restores the saved timezone in the upload modal', () => {
+    const futureExpiry = Date.now() + 3600 * 1000;
+
+    cy.visit('/examples/index.html', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('audio-recorder-pipeline-timezone', 'America/New_York');
+        win.localStorage.setItem('audio-recorder-youtube-token-state', JSON.stringify({
+          accessToken: 'stored-token',
+          accessTokenExpiresAt: futureExpiry,
+        }));
+      },
+    });
+    cy.waitForVisualization();
+
+    addSyntheticRecording();
+    cy.contains('button', 'Upload to YouTube').click();
+
+    cy.get('#youtubeUploadModal').should('be.visible');
+    cy.get('#youtubeTimezone').should('have.value', 'America/New_York');
+  });
+
   it('keeps the upload form open when text selection ends outside the form', () => {
     cy.visit('/examples/index.html', {
       onBeforeLoad(win) {

--- a/cypress/e2e/youtube-upload-ui.cy.js
+++ b/cypress/e2e/youtube-upload-ui.cy.js
@@ -700,4 +700,58 @@ describe('YouTube Upload UI', () => {
     cy.get('#youtubeUploadModal').should('be.visible');
     cy.get('#youtubeDescription').should('have.value', 'Rendered from Cypress');
   });
+
+  it('shows Google account and timezone fields in the Settings modal', () => {
+    cy.visit('/examples/index.html');
+    cy.waitForVisualization();
+
+    cy.get('#presetSettingsBtn').click();
+
+    cy.get('#presetSettingsModal').should('be.visible');
+    cy.get('#settingsYoutubeClientId').should('exist').and('be.visible');
+    cy.get('#settingsYoutubeClientSecret').should('exist').and('be.visible');
+    cy.get('#settingsUploadTimezone').should('exist').and('be.visible');
+    cy.get('#settingsUploadTimezone option[value=""]').should('contain.text', 'Browser timezone');
+    cy.get('#settingsUploadTimezone option[value="UTC"]').should('exist');
+    cy.get('#settingsUploadTimezone option[value="Europe/Moscow"]').should('exist');
+  });
+
+  it('saves OAuth client ID entered in Settings to the auth modal', () => {
+    cy.visit('/examples/index.html');
+    cy.waitForVisualization();
+
+    cy.get('#presetSettingsBtn').click();
+    cy.get('#settingsYoutubeClientId').type('123-settings-test.apps.googleusercontent.com');
+    cy.get('#presetSettingsCloseBtn').click();
+
+    addSyntheticRecording();
+    cy.contains('button', 'Upload to YouTube').click();
+
+    cy.get('#youtubeAuthModal').should('be.visible');
+    cy.get('#youtubeClientId').should('have.value', '123-settings-test.apps.googleusercontent.com');
+  });
+
+  it('saves the Settings timezone and pre-selects it in the upload modal', () => {
+    const futureExpiry = Date.now() + 3600 * 1000;
+
+    cy.visit('/examples/index.html', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('audio-recorder-youtube-token-state', JSON.stringify({
+          accessToken: 'stored-token',
+          accessTokenExpiresAt: futureExpiry,
+        }));
+      },
+    });
+    cy.waitForVisualization();
+
+    cy.get('#presetSettingsBtn').click();
+    cy.get('#settingsUploadTimezone').select('Europe/Moscow');
+    cy.get('#presetSettingsCloseBtn').click();
+
+    addSyntheticRecording();
+    cy.contains('button', 'Upload to YouTube').click();
+
+    cy.get('#youtubeUploadModal').should('be.visible');
+    cy.get('#youtubeTimezone').should('have.value', 'Europe/Moscow');
+  });
 });

--- a/examples/index.html
+++ b/examples/index.html
@@ -11,7 +11,7 @@
   <aside class="preset-sidebar" id="presetSidebar" aria-label="Preset sidebar">
     <button type="button" class="preset-icon-btn" id="savePresetBtn" data-tooltip="Save preset" aria-label="Save preset">💾</button>
     <div class="preset-list" id="presetList" aria-label="Saved presets"></div>
-    <button type="button" class="preset-icon-btn preset-settings-btn" id="presetSettingsBtn" data-tooltip="Preset settings" aria-label="Preset settings">⚙️</button>
+    <button type="button" class="preset-icon-btn preset-settings-btn" id="presetSettingsBtn" data-tooltip="Settings" aria-label="Settings">⚙️</button>
   </aside>
   <aside class="pipeline-sidebar" id="pipelineSidebar" aria-label="Pipeline sidebar">
     <button type="button" class="preset-icon-btn" id="savePipelineBtn" data-tooltip="Save pipeline" aria-label="Save pipeline">💾</button>
@@ -1025,13 +1025,35 @@
 
   <div class="modal-overlay" id="presetSettingsModal" aria-hidden="true">
     <div class="preset-modal" role="dialog" aria-modal="true" aria-labelledby="presetSettingsTitle">
-      <h2 id="presetSettingsTitle">Preset Settings</h2>
+      <h2 id="presetSettingsTitle">Settings</h2>
       <label>
         Preset Save Path
         <div class="folder-row">
           <input type="text" id="presetSettingsPathInput" readonly>
           <button type="button" class="btn-secondary compact-btn" id="presetSettingsChooseFolderBtn">Choose</button>
         </div>
+      </label>
+      <label data-tooltip="OAuth 2.0 Client ID from Google Cloud Console with YouTube Data API v3 enabled">
+        Google OAuth Client ID
+        <input type="text" id="settingsYoutubeClientId" autocomplete="off" spellcheck="false" aria-label="Google OAuth client ID (settings)">
+      </label>
+      <label data-tooltip="Optional client secret from a Google Desktop app OAuth client. Leave blank when using a Web application client in browser mode.">
+        Google Desktop Client Secret
+        <input type="password" id="settingsYoutubeClientSecret" autocomplete="off" spellcheck="false" aria-label="Google desktop OAuth client secret (settings)">
+      </label>
+      <label data-tooltip="Default timezone for scheduling YouTube uploads. Applies to both single video uploads and the pipeline.">
+        Upload Timezone
+        <select id="settingsUploadTimezone" aria-label="Default YouTube upload timezone">
+          <option value="">Browser timezone</option>
+          <option value="UTC">UTC</option>
+          <option value="Europe/Moscow">Europe/Moscow</option>
+          <option value="America/New_York">America/New_York</option>
+          <option value="America/Chicago">America/Chicago</option>
+          <option value="America/Denver">America/Denver</option>
+          <option value="America/Los_Angeles">America/Los_Angeles</option>
+          <option value="Asia/Yekaterinburg">Asia/Yekaterinburg</option>
+          <option value="Asia/Tbilisi">Asia/Tbilisi</option>
+        </select>
       </label>
       <div class="modal-actions">
         <button type="button" class="btn-primary compact-btn" id="presetSettingsCloseBtn">Done</button>

--- a/examples/index.html
+++ b/examples/index.html
@@ -804,6 +804,20 @@
               Publish at
               <input type="datetime-local" id="youtubePublishAt" aria-label="Scheduled YouTube publish date and time">
             </label>
+            <label>
+              Timezone
+              <select id="youtubeTimezone" aria-label="YouTube scheduled publish timezone">
+                <option value="">Browser timezone</option>
+                <option value="UTC">UTC</option>
+                <option value="Europe/Moscow">Europe/Moscow</option>
+                <option value="America/New_York">America/New_York</option>
+                <option value="America/Chicago">America/Chicago</option>
+                <option value="America/Denver">America/Denver</option>
+                <option value="America/Los_Angeles">America/Los_Angeles</option>
+                <option value="Asia/Yekaterinburg">Asia/Yekaterinburg</option>
+                <option value="Asia/Tbilisi">Asia/Tbilisi</option>
+              </select>
+            </label>
             <label class="youtube-wide-field">
               Description
               <textarea id="youtubeDescription" rows="5" aria-label="YouTube video description"></textarea>

--- a/examples/youtube-upload.js
+++ b/examples/youtube-upload.js
@@ -22,6 +22,7 @@
   const UPLOAD_FORM_STATE_KEY = 'audio-recorder-youtube-upload-form-state';
   const TOKEN_STATE_KEY = 'audio-recorder-youtube-token-state';
   const PLAYLISTS_KEY = 'audio-recorder-youtube-playlists';
+  const TIMEZONE_KEY = 'audio-recorder-pipeline-timezone';
   const TOKEN_EXPIRY_SKEW_MS = 60000;
   const LOCALHOST_EXAMPLE_ORIGIN = 'http://localhost:8080';
   const UNSUPPORTED_ORIGIN_MESSAGE = 'Google sign-in requires a localhost or HTTPS URL. Open the app with npm run serve or Electron, then use the localhost page.';
@@ -52,6 +53,7 @@
   const categorySelect = document.getElementById('youtubeCategory');
   const privacySelect = document.getElementById('youtubePrivacy');
   const publishAtInput = document.getElementById('youtubePublishAt');
+  const timezoneSelect = document.getElementById('youtubeTimezone');
   const shortCheckbox = document.getElementById('youtubeShort');
   const madeForKidsCheckbox = document.getElementById('youtubeMadeForKids');
   const syntheticMediaCheckbox = document.getElementById('youtubeSyntheticMedia');
@@ -66,7 +68,7 @@
     authModal, closeAuthBtn, cancelAuthBtn, openGoogleCloudOAuthBtn, authorizeBtn,
     clientIdInput, clientSecretField, clientSecretInput, authSettingsStatus, signOutBtn, signInSettingsBtn, authStatus,
     uploadModal, closeUploadBtn, uploadForm, titleInput, descriptionInput, tagsInput, playlistIdsInput, playlistSelector, thumbnailInput,
-    categorySelect, privacySelect, publishAtInput, shortCheckbox, madeForKidsCheckbox, syntheticMediaCheckbox,
+    categorySelect, privacySelect, publishAtInput, timezoneSelect, shortCheckbox, madeForKidsCheckbox, syntheticMediaCheckbox,
     notifySubscribersCheckbox, progressBar, progressFill, uploadStatus, cancelUploadBtn,
     submitUploadBtn,
   ];
@@ -574,6 +576,11 @@
     };
 
     localStorage.setItem(getUploadFormStateKey(), JSON.stringify(state));
+
+    const timezone = timezoneSelect.value;
+    if (timezone) {
+      localStorage.setItem(TIMEZONE_KEY, timezone);
+    }
   }
 
   function resetProgress() {
@@ -592,12 +599,53 @@
     return new Date(date.getTime() - offsetMs).toISOString().slice(0, 16);
   }
 
+  function getSelectedTimezone() {
+    return timezoneSelect.value || '';
+  }
+
+  function parsePublishAtInTimezone(value, timezone) {
+    if (!value) return null;
+    if (!timezone) return new Date(value);
+    // Interpret the datetime-local string as wall-clock time in the given timezone.
+    // Strategy: start with the UTC time assuming 0 offset, then iteratively correct
+    // using the actual offset at that UTC time in the target timezone.
+    const [datePart, timePart] = value.split('T');
+    if (!datePart || !timePart) return new Date(value);
+    const [year, month, day] = datePart.split('-').map(Number);
+    const [hour, minute] = timePart.split(':').map(Number);
+    const getOffsetMs = (utcDate) => {
+      const parts = {};
+      new Intl.DateTimeFormat('en-CA', {
+        timeZone: timezone,
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+      }).formatToParts(utcDate).forEach(({ type, value: v }) => { parts[type] = v; });
+      const localMs = Date.UTC(
+        Number(parts.year),
+        Number(parts.month) - 1,
+        Number(parts.day),
+        Number(parts.hour === '24' ? 0 : parts.hour),
+        Number(parts.minute),
+      );
+      return utcDate.getTime() - localMs;
+    };
+    const naiveUtc = new Date(Date.UTC(year, month - 1, day, hour, minute));
+    const offsetMs = getOffsetMs(naiveUtc);
+    return new Date(naiveUtc.getTime() + offsetMs);
+  }
+
   function getScheduledPublishAt() {
     if (!publishAtInput.value) {
       return undefined;
     }
 
-    return new Date(publishAtInput.value).toISOString();
+    const timezone = getSelectedTimezone();
+    const date = parsePublishAtInTimezone(publishAtInput.value, timezone);
+    return date ? date.toISOString() : undefined;
   }
 
   function updateScheduleState() {
@@ -678,6 +726,14 @@
     privacySelect.value = savedState.privacyStatus;
     privacySelect.disabled = false;
     publishAtInput.value = '';
+    const savedTimezone = localStorage.getItem(TIMEZONE_KEY) || '';
+    if (savedTimezone && !Array.from(timezoneSelect.options).some(opt => opt.value === savedTimezone)) {
+      const opt = document.createElement('option');
+      opt.value = savedTimezone;
+      opt.textContent = savedTimezone;
+      timezoneSelect.insertBefore(opt, timezoneSelect.firstChild);
+    }
+    timezoneSelect.value = savedTimezone;
     setMinimumPublishAt();
     shortCheckbox.checked = savedState.short;
     madeForKidsCheckbox.checked = savedState.madeForKids;

--- a/examples/youtube-upload.js
+++ b/examples/youtube-upload.js
@@ -41,6 +41,10 @@
   const signInSettingsBtn = document.getElementById('youtubeSignInSettingsBtn');
   const authStatus = document.getElementById('youtubeAuthStatus');
 
+  const settingsClientIdInput = document.getElementById('settingsYoutubeClientId');
+  const settingsClientSecretInput = document.getElementById('settingsYoutubeClientSecret');
+  const settingsTimezoneSelect = document.getElementById('settingsUploadTimezone');
+
   const uploadModal = document.getElementById('youtubeUploadModal');
   const closeUploadBtn = document.getElementById('closeYouTubeUploadBtn');
   const uploadForm = document.getElementById('youtubeUploadForm');
@@ -89,6 +93,36 @@
 
   clientIdInput.value = localStorage.getItem(CLIENT_ID_KEY) || '';
   restoreStoredTokenState();
+
+  if (settingsClientIdInput) {
+    settingsClientIdInput.value = localStorage.getItem(CLIENT_ID_KEY) || '';
+    settingsClientIdInput.addEventListener('input', () => {
+      clientIdInput.value = settingsClientIdInput.value;
+      localStorage.setItem(CLIENT_ID_KEY, settingsClientIdInput.value.trim());
+    });
+  }
+
+  if (settingsClientSecretInput) {
+    settingsClientSecretInput.addEventListener('input', () => {
+      clientSecretInput.value = settingsClientSecretInput.value;
+    });
+  }
+
+  if (settingsTimezoneSelect) {
+    const savedTimezone = localStorage.getItem(TIMEZONE_KEY) || '';
+    if (savedTimezone && !Array.from(settingsTimezoneSelect.options).some(opt => opt.value === savedTimezone)) {
+      const opt = document.createElement('option');
+      opt.value = savedTimezone;
+      opt.textContent = savedTimezone;
+      settingsTimezoneSelect.insertBefore(opt, settingsTimezoneSelect.firstChild);
+    }
+    settingsTimezoneSelect.value = savedTimezone;
+    settingsTimezoneSelect.addEventListener('change', () => {
+      const tz = settingsTimezoneSelect.value;
+      localStorage.setItem(TIMEZONE_KEY, tz);
+      timezoneSelect.value = tz;
+    });
+  }
 
   function showModal(modal) {
     modal.style.display = 'flex';
@@ -665,7 +699,13 @@
   }
 
   function openAuthModal() {
+    if (settingsClientIdInput && settingsClientIdInput.value.trim()) {
+      clientIdInput.value = settingsClientIdInput.value;
+    }
     updateAuthModeFields();
+    if (settingsClientSecretInput && settingsClientSecretInput.value && !clientSecretInput.value) {
+      clientSecretInput.value = settingsClientSecretInput.value;
+    }
     updateAuthSettingsStatus();
     authorizeBtn.textContent = 'Sign in with Google';
     showModal(authModal);
@@ -1045,4 +1085,22 @@
       closeAuthModal();
     }
   });
+
+  clientIdInput.addEventListener('input', () => {
+    if (settingsClientIdInput) {
+      settingsClientIdInput.value = clientIdInput.value;
+    }
+    localStorage.setItem(CLIENT_ID_KEY, clientIdInput.value.trim());
+  });
+
+  const presetSettingsBtn = document.getElementById('presetSettingsBtn');
+  if (presetSettingsBtn && settingsClientIdInput) {
+    presetSettingsBtn.addEventListener('click', () => {
+      settingsClientIdInput.value = localStorage.getItem(CLIENT_ID_KEY) || '';
+      if (settingsTimezoneSelect) {
+        const savedTz = localStorage.getItem(TIMEZONE_KEY) || '';
+        settingsTimezoneSelect.value = savedTz;
+      }
+    });
+  }
 })();


### PR DESCRIPTION
## Summary

Fixes #149

When uploading a single visualized video to YouTube there was no timezone selector — the browser's local timezone was used implicitly. Pipeline mode had this setting but the single upload form did not. There was also no global timezone or Google account setting outside the upload/auth modals.

## Changes

- **`examples/index.html`**:
  - Renamed the \"Preset Settings\" modal to **\"Settings\"** (as this modal covers all global settings, not just presets).
  - Added a **Google OAuth Client ID** field to the Settings modal so credentials can be entered once without opening the auth modal.
  - Added a **Google Desktop Client Secret** field to the Settings modal (used in Electron Desktop app OAuth flow).
  - Added an **Upload Timezone** selector to the Settings modal — a global default timezone for all YouTube uploads (both single and pipeline).
  - Added a **Timezone** select field to the YouTube upload modal, next to the **Publish at** field.

- **`examples/youtube-upload.js`**:
  - Reads Google OAuth Client ID and timezone from the Settings modal and syncs them to the auth modal and upload modal bidirectionally.
  - The Settings timezone is persisted to `localStorage` under the existing `audio-recorder-pipeline-timezone` key, so it is shared between single upload and pipeline modes.
  - On auth modal open, pre-fills the Client ID (and secret in Electron mode) from the Settings modal values.
  - On Settings modal open, refreshes its fields from `localStorage`.
  - Added `parsePublishAtInTimezone()` using `Intl.DateTimeFormat` to accurately convert a `datetime-local` value in the selected timezone to the correct UTC ISO string for the YouTube API.

- **`cypress/e2e/youtube-upload-ui.cy.js`**: Added six Cypress tests:
  1. Verifies the timezone selector is visible in the upload modal with the expected options.
  2. Verifies that selecting `Europe/Moscow` (UTC+3) and entering `15:30` results in `12:30 UTC` being sent to the YouTube API.
  3. Verifies that a timezone saved in `localStorage` is restored when the upload modal opens.
  4. Verifies the Google account and timezone fields are visible in the Settings modal.
  5. Verifies that an OAuth Client ID entered in Settings is propagated to the auth modal.
  6. Verifies that a timezone selected in Settings is pre-selected in the upload modal.

## How to reproduce the original issue

1. Record/convert an audio file to produce a visualized video.
2. Click \"Upload to YouTube\", sign in, and open the upload modal.
3. Previously: only a `Publish at` datetime-local field — no way to specify which timezone that date/time is in.
4. After this fix: a `Timezone` selector appears next to `Publish at`.
5. Previously: OAuth credentials could only be entered in the upload/auth modals, not in Settings.
6. After this fix: the Settings modal (⚙️ button) includes Google account fields and a global timezone selector.

## Test plan

- [ ] Open the Settings modal (⚙️ in preset sidebar) — verify Google OAuth Client ID, Desktop Client Secret, and Upload Timezone fields are present.
- [ ] Enter an OAuth Client ID in Settings, then click \"Upload to YouTube\" — verify the auth modal pre-fills the Client ID.
- [ ] Select a timezone in Settings, then open the upload modal — verify the timezone is pre-selected.
- [ ] Open the YouTube upload modal and verify the Timezone selector is present.
- [ ] Select a non-browser timezone, enter a publish time, submit — verify the API receives the correct UTC time.
- [ ] Run `npm test` — all 341 unit tests pass.
- [ ] Run `npm run test:e2e` — all Cypress tests including the new timezone and settings tests pass.