### PR TITLE
fix: show release date with compact relative offset in pipeline stage navbar

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-21T04:36:09.063Z for PR creation at branch issue-161-d151d763b814 for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/161

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-21T04:36:09.063Z for PR creation at branch issue-161-d151d763b814 for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/161

--- a/cypress/e2e/pipeline-mode.cy.js
+++ b/cypress/e2e/pipeline-mode.cy.js
@@ -238,7 +238,7 @@ describe('Pipeline Mode', () => {
       .and('contain.text', 'Visualization + update')
       .invoke('text')
       .should('match', /\d{4}-\d{2}-\d{2}/)
-      .and('match', /\(-\d+d\/\d+h\/\d+m\)/);
+      .and('match', /\(-\d+[dhm]( \d+[hm])*\)/);
     cy.get('#pipelineStageNav .pipeline-stage-nav-btn').eq(1)
       .should('contain.text', 'Release')
       .and('contain.text', 'Visualization + update')

--- a/cypress/e2e/pipeline-mode.cy.js
+++ b/cypress/e2e/pipeline-mode.cy.js
@@ -237,7 +237,8 @@ describe('Pipeline Mode', () => {
       .and('contain.text', 'Pre-save short')
       .and('contain.text', 'Visualization + update')
       .invoke('text')
-      .should('match', /-\d+ min/);
+      .should('match', /\d{4}-\d{2}-\d{2}/)
+      .and('match', /\(-\d+d\/\d+h\/\d+m\)/);
     cy.get('#pipelineStageNav .pipeline-stage-nav-btn').eq(1)
       .should('contain.text', 'Release')
       .and('contain.text', 'Visualization + update')

--- a/examples/pipeline.js
+++ b/examples/pipeline.js
@@ -1663,7 +1663,14 @@
     return tasks;
   }
 
-  function getStageDisplayDate(stage) {
+  function formatRelativeOffsetCompact(stage) {
+    const parts = getRelativeOffsetParts(stage);
+    const sign = parts.direction === 'before' ? '-' : '+';
+    const d = parts.days + parts.months * 30;
+    return `${sign}${d}d/${parts.hours}h/${parts.minutes}m`;
+  }
+
+  function getStageDisplayDate(stage, computedDate) {
     if (!actionIncludesUpload(stage.action)) {
       return '';
     }
@@ -1676,9 +1683,16 @@
     if (stage.scheduleMode === 'absolute' && stage.publishAtLocal) {
       return stage.publishAtLocal.replace('T', ' ');
     }
-    const offset = Number(stage.relativeOffsetMinutes || 0);
-    const sign = offset > 0 ? '+' : '';
-    return `${sign}${offset} min`;
+    const relativeLabel = `(${formatRelativeOffsetCompact(stage)})`;
+    if (computedDate && Number.isFinite(computedDate.getTime())) {
+      const year = computedDate.getFullYear();
+      const month = String(computedDate.getMonth() + 1).padStart(2, '0');
+      const day = String(computedDate.getDate()).padStart(2, '0');
+      const hours = String(computedDate.getHours()).padStart(2, '0');
+      const minutes = String(computedDate.getMinutes()).padStart(2, '0');
+      return `${year}-${month}-${day} ${hours}:${minutes} ${relativeLabel}`;
+    }
+    return relativeLabel;
   }
 
   function setActiveStage(stageId) {
@@ -1752,9 +1766,10 @@
     }
 
     stageNav.hidden = false;
+    const stageBaseDates = computeStageBaseDates();
     stages.forEach((stage, index) => {
       const button = document.createElement('button');
-      const dateText = getStageDisplayDate(stage);
+      const dateText = getStageDisplayDate(stage, stageBaseDates[index]);
       button.type = 'button';
       button.className = 'pipeline-stage-nav-btn';
       button.dataset.stageId = stage.id;

--- a/examples/pipeline.js
+++ b/examples/pipeline.js
@@ -1667,7 +1667,12 @@
     const parts = getRelativeOffsetParts(stage);
     const sign = parts.direction === 'before' ? '-' : '+';
     const d = parts.days + parts.months * 30;
-    return `${sign}${d}d/${parts.hours}h/${parts.minutes}m`;
+    const segments = [];
+    if (d !== 0) segments.push(`${d}d`);
+    if (parts.hours !== 0) segments.push(`${parts.hours}h`);
+    if (parts.minutes !== 0) segments.push(`${parts.minutes}m`);
+    if (segments.length === 0) segments.push('0m');
+    return `${sign}${segments.join(' ')}`;
   }
 
   function getStageDisplayDate(stage, computedDate) {


### PR DESCRIPTION
## Summary

- Fixes the time display format for relative pipeline stages in the navbar (issue #161)
- Replaces the raw minute offset (e.g. `-10080 min`) with the **computed release date** plus a compact relative offset using space-separated non-zero parts
- Example: `2024-06-28 15:30 (-7d)` for a 7-day offset, `2024-06-28 15:30 (+1d 30m)` for 1 day and 30 minutes
- Falls back to just `(±Xd Yh Zm)` if the date cannot be computed

## How it works

- `formatRelativeOffsetCompact(stage)` produces a compact offset like `+1d 30m` or `-7d`: uses spaces as separators and skips any zero-value fields (so `-7d/0h/0m` → `-7d`, `+1d/0h/30m` → `+1d 30m`)
- `getStageDisplayDate(stage, computedDate)` formats the date as `YYYY-MM-DD HH:MM (relative)`
- `renderStageNav()` calls `computeStageBaseDates()` and passes each stage's resolved date

## Test plan

- [x] All existing unit tests pass (`npm test`)
- [x] Updated Cypress test `pipeline-mode.cy.js` to assert the new format: date matches `/\d{4}-\d{2}-\d{2}/` and relative offset matches `/\(-\d+[dhm]( \d+[hm])*\)/`
- [ ] Verify in the app: add a relative pipeline stage and confirm the navbar shows the release date with compact relative offset

Fixes Jhon-Crow/audio-recorder-with-visualization#161