### PR TITLE
fix: persist Google Desktop Client Secret across page reloads

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-21T05:07:26.915Z for PR creation at branch issue-163-31ba05ff7c5b for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/163

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-21T05:07:26.915Z for PR creation at branch issue-163-31ba05ff7c5b for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/163

--- a/cypress/e2e/youtube-upload-ui.cy.js
+++ b/cypress/e2e/youtube-upload-ui.cy.js
@@ -731,6 +731,40 @@ describe('YouTube Upload UI', () => {
     cy.get('#youtubeClientId').should('have.value', '123-settings-test.apps.googleusercontent.com');
   });
 
+  it('persists the Desktop Client Secret from Settings across page reloads', () => {
+    cy.visit('/examples/index.html');
+    cy.waitForVisualization();
+
+    cy.get('#presetSettingsBtn').click();
+    cy.get('#settingsYoutubeClientSecret').type('test-secret-value');
+    cy.get('#presetSettingsCloseBtn').click();
+
+    cy.window().then((win) => {
+      expect(win.localStorage.getItem('audio-recorder-youtube-client-secret')).to.equal('test-secret-value');
+    });
+
+    cy.reload();
+    cy.waitForVisualization();
+
+    cy.get('#presetSettingsBtn').click();
+    cy.get('#settingsYoutubeClientSecret').should('have.value', 'test-secret-value');
+  });
+
+  it('shows Desktop Client Secret from Settings in the auth modal', () => {
+    cy.visit('/examples/index.html', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('audio-recorder-youtube-client-secret', 'stored-secret');
+      },
+    });
+    cy.waitForVisualization();
+
+    addSyntheticRecording();
+    cy.contains('button', 'Upload to YouTube').click();
+
+    cy.get('#youtubeAuthModal').should('be.visible');
+    cy.get('#youtubeClientSecret').should('have.value', 'stored-secret');
+  });
+
   it('saves the Settings timezone and pre-selects it in the upload modal', () => {
     const futureExpiry = Date.now() + 3600 * 1000;
 

--- a/examples/youtube-upload.js
+++ b/examples/youtube-upload.js
@@ -19,6 +19,7 @@
   }
 
   const CLIENT_ID_KEY = 'audio-recorder-youtube-client-id';
+  const CLIENT_SECRET_KEY = 'audio-recorder-youtube-client-secret';
   const UPLOAD_FORM_STATE_KEY = 'audio-recorder-youtube-upload-form-state';
   const TOKEN_STATE_KEY = 'audio-recorder-youtube-token-state';
   const PLAYLISTS_KEY = 'audio-recorder-youtube-playlists';
@@ -92,6 +93,7 @@
   let playlistRefreshPromise = null;
 
   clientIdInput.value = localStorage.getItem(CLIENT_ID_KEY) || '';
+  clientSecretInput.value = localStorage.getItem(CLIENT_SECRET_KEY) || '';
   restoreStoredTokenState();
 
   if (settingsClientIdInput) {
@@ -103,8 +105,10 @@
   }
 
   if (settingsClientSecretInput) {
+    settingsClientSecretInput.value = localStorage.getItem(CLIENT_SECRET_KEY) || '';
     settingsClientSecretInput.addEventListener('input', () => {
       clientSecretInput.value = settingsClientSecretInput.value;
+      localStorage.setItem(CLIENT_SECRET_KEY, settingsClientSecretInput.value.trim());
     });
   }
 
@@ -1097,6 +1101,9 @@
   if (presetSettingsBtn && settingsClientIdInput) {
     presetSettingsBtn.addEventListener('click', () => {
       settingsClientIdInput.value = localStorage.getItem(CLIENT_ID_KEY) || '';
+      if (settingsClientSecretInput) {
+        settingsClientSecretInput.value = localStorage.getItem(CLIENT_SECRET_KEY) || '';
+      }
       if (settingsTimezoneSelect) {
         const savedTz = localStorage.getItem(TIMEZONE_KEY) || '';
         settingsTimezoneSelect.value = savedTz;


### PR DESCRIPTION
## Summary

- **Root cause**: The `clientSecret` field in the Settings modal was never saved to `localStorage`, while `clientId` already was. On every page reload, the secret field was empty.
- **Fix**: Added `CLIENT_SECRET_KEY = 'audio-recorder-youtube-client-secret'` and wired it up symmetrically to `clientId`: save on input, restore on init and when the Settings modal opens.
- **Tests**: Added two Cypress tests — one verifying the secret persists across `cy.reload()`, another verifying it pre-fills the auth modal from `localStorage`.

## How to reproduce the issue

1. Open the app, click ⚙️ Settings
2. Enter a value in "Google Desktop Client Secret"
3. Close settings and reload the page
4. Open Settings again — the field is empty

## After the fix

The Desktop Client Secret is saved to `localStorage` on every keystroke and restored on page load, matching the existing behavior for the Client ID field.

Fixes #163