### PR TITLE
fix: add right-click context menu with cut/copy/paste for input fields

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-22T08:15:29.360Z for PR creation at branch issue-165-36d035881f61 for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/165

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-22T08:15:29.360Z for PR creation at branch issue-165-36d035881f61 for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/165

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain, shell, dialog, screen, globalShortcut } = require('electron');
+const { app, BrowserWindow, ipcMain, shell, dialog, screen, globalShortcut, Menu } = require('electron');
 const path = require('path');
 const fs = require('fs');
 const http = require('http');
@@ -721,6 +721,31 @@ app.on('web-contents-created', (event, contents) => {
       callback(true);
     } else {
       callback(false);
+    }
+  });
+
+  contents.on('context-menu', (menuEvent, params) => {
+    const { isEditable, selectionText, editFlags } = params;
+    if (!isEditable && !selectionText) {
+      return;
+    }
+
+    const menuItems = [];
+
+    if (isEditable) {
+      menuItems.push(
+        { role: 'cut', enabled: editFlags.canCut },
+        { role: 'copy', enabled: editFlags.canCopy },
+        { role: 'paste', enabled: editFlags.canPaste },
+        { type: 'separator' },
+        { role: 'selectAll', enabled: editFlags.canSelectAll }
+      );
+    } else if (selectionText) {
+      menuItems.push({ role: 'copy', enabled: editFlags.canCopy });
+    }
+
+    if (menuItems.length > 0) {
+      Menu.buildFromTemplate(menuItems).popup({ window: BrowserWindow.fromWebContents(contents) });
     }
   });
 });

--- a/tests/electron-context-menu.test.ts
+++ b/tests/electron-context-menu.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for the Electron context menu on right-click in editable input fields.
+ *
+ * The main.js `web-contents-created` handler attaches a `context-menu` listener
+ * to every WebContents. When a user right-clicks on an editable element, Electron
+ * fires `context-menu` with `params.isEditable = true` and `params.editFlags`
+ * describing which clipboard operations are available. The handler should build and
+ * show a menu with cut/copy/paste/select-all items.
+ *
+ * These tests verify that behavior by simulating the handler logic directly.
+ */
+
+type EditFlags = {
+  canCut: boolean;
+  canCopy: boolean;
+  canPaste: boolean;
+  canSelectAll: boolean;
+};
+
+type ContextMenuParams = {
+  isEditable: boolean;
+  selectionText: string;
+  editFlags: EditFlags;
+};
+
+type MenuItem = {
+  role?: string;
+  type?: string;
+  enabled?: boolean;
+};
+
+function buildContextMenuItems(params: ContextMenuParams): MenuItem[] {
+  const { isEditable, selectionText, editFlags } = params;
+
+  if (!isEditable && !selectionText) {
+    return [];
+  }
+
+  const menuItems: MenuItem[] = [];
+
+  if (isEditable) {
+    menuItems.push(
+      { role: 'cut', enabled: editFlags.canCut },
+      { role: 'copy', enabled: editFlags.canCopy },
+      { role: 'paste', enabled: editFlags.canPaste },
+      { type: 'separator' },
+      { role: 'selectAll', enabled: editFlags.canSelectAll }
+    );
+  } else if (selectionText) {
+    menuItems.push({ role: 'copy', enabled: editFlags.canCopy });
+  }
+
+  return menuItems;
+}
+
+describe('Electron context menu (right-click on inputs)', () => {
+  const fullEditFlags: EditFlags = {
+    canCut: true,
+    canCopy: true,
+    canPaste: true,
+    canSelectAll: true,
+  };
+
+  test('shows cut/copy/paste/selectAll for editable input with text selected', () => {
+    const items = buildContextMenuItems({
+      isEditable: true,
+      selectionText: 'hello',
+      editFlags: fullEditFlags,
+    });
+
+    expect(items.length).toBeGreaterThan(0);
+    expect(items.some(i => i.role === 'cut')).toBe(true);
+    expect(items.some(i => i.role === 'copy')).toBe(true);
+    expect(items.some(i => i.role === 'paste')).toBe(true);
+    expect(items.some(i => i.role === 'selectAll')).toBe(true);
+  });
+
+  test('shows menu for editable input even when nothing is selected', () => {
+    const items = buildContextMenuItems({
+      isEditable: true,
+      selectionText: '',
+      editFlags: { canCut: false, canCopy: false, canPaste: true, canSelectAll: true },
+    });
+
+    expect(items.length).toBeGreaterThan(0);
+    expect(items.some(i => i.role === 'paste')).toBe(true);
+    expect(items.some(i => i.role === 'selectAll')).toBe(true);
+  });
+
+  test('respects editFlags.canCut / canCopy enabled state', () => {
+    const items = buildContextMenuItems({
+      isEditable: true,
+      selectionText: '',
+      editFlags: { canCut: false, canCopy: false, canPaste: true, canSelectAll: true },
+    });
+
+    const cutItem = items.find(i => i.role === 'cut');
+    const copyItem = items.find(i => i.role === 'copy');
+
+    expect(cutItem?.enabled).toBe(false);
+    expect(copyItem?.enabled).toBe(false);
+  });
+
+  test('shows only copy for non-editable element with selected text', () => {
+    const items = buildContextMenuItems({
+      isEditable: false,
+      selectionText: 'selected text',
+      editFlags: { canCut: false, canCopy: true, canPaste: false, canSelectAll: false },
+    });
+
+    expect(items.length).toBe(1);
+    expect(items[0].role).toBe('copy');
+  });
+
+  test('returns no items for non-editable element with no selection', () => {
+    const items = buildContextMenuItems({
+      isEditable: false,
+      selectionText: '',
+      editFlags: { canCut: false, canCopy: false, canPaste: false, canSelectAll: false },
+    });
+
+    expect(items.length).toBe(0);
+  });
+
+  test('includes a separator between clipboard actions and selectAll', () => {
+    const items = buildContextMenuItems({
+      isEditable: true,
+      selectionText: '',
+      editFlags: fullEditFlags,
+    });
+
+    const separatorIndex = items.findIndex(i => i.type === 'separator');
+    const selectAllIndex = items.findIndex(i => i.role === 'selectAll');
+
+    expect(separatorIndex).toBeGreaterThan(-1);
+    expect(selectAllIndex).toBeGreaterThan(separatorIndex);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes Jhon-Crow/audio-recorder-with-visualization#165

Right-clicking on an input field in the Electron app showed no context menu, making it impossible to cut, copy, or paste text using the mouse. This is a known gap in Electron — the default Chromium context menu is suppressed, so it must be wired up manually.

- Added `Menu` to the Electron imports in `electron/main.js`
- Attached a `context-menu` listener inside the existing `web-contents-created` handler
- The listener uses `params.isEditable` and `params.editFlags` to build an appropriate menu:
  - **Editable elements** (inputs, textareas): cut, copy, paste, separator, select-all — each item enabled/disabled according to `editFlags`
  - **Non-editable elements with a selection**: copy only
  - **Nothing editable/selected**: no menu shown
- The menu is shown via `Menu.buildFromTemplate(...).popup(...)` and applies to every WebContents (main window and presentation window)

## How to reproduce the issue

1. Run `npm run electron`
2. Right-click on any text input (e.g. preset name, YouTube Client ID field)
3. Before: no context menu appears
4. After: a native-style menu with Cut / Copy / Paste / Select All is shown

## Test plan

- [x] New unit test `tests/electron-context-menu.test.ts` covers the menu-building logic:
  - Editable field with text selected → cut/copy/paste/selectAll all present
  - Editable field with nothing selected → paste/selectAll present; cut/copy disabled
  - `editFlags` disable bits are reflected in item `enabled` state
  - Non-editable with selection → copy only
  - Non-editable with no selection → no menu
  - Separator appears between clipboard items and selectAll
- [x] Full test suite passes (`347 tests, 10 suites`)