### PR TITLE
Fix pipeline playlist creation refresh

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-23T03:26:07.797Z for PR creation at branch issue-169-eec41b57b4ff for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/169

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-23T03:26:07.797Z for PR creation at branch issue-169-eec41b57b4ff for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/169

--- a/cypress/e2e/pipeline-mode.cy.js
+++ b/cypress/e2e/pipeline-mode.cy.js
@@ -635,6 +635,10 @@ describe('Pipeline Mode', () => {
     cy.wait('@createPipelineStagePlaylist');
     cy.get('.pipeline-stage').first().find('.pipeline-stage-playlist-ids')
       .should('have.value', 'PL-existing, PL-created');
+    cy.get('.pipeline-stage').first()
+      .contains('.youtube-playlist-option', 'Pipeline created playlist')
+      .find('input')
+      .should('be.checked');
   });
 
   it('blocks out-of-order YouTube uploads by default and allows manual order from settings', () => {

--- a/examples/pipeline.js
+++ b/examples/pipeline.js
@@ -2737,7 +2737,7 @@
   }
 
   function renderPlaylistChooser(stage, onChange) {
-    const selectedIds = getPlaylistIds(stage.playlistIds);
+    let selectedIds = getPlaylistIds(stage.playlistIds);
     const youtube = window.AudioRecorderYouTube;
     const known = youtube && typeof youtube.getSavedPlaylists === 'function'
       ? youtube.getSavedPlaylists()
@@ -2761,6 +2761,7 @@
     list.className = 'youtube-playlist-list';
     const setSelectedIds = (ids) => {
       const nextIds = ids.filter((item, index, list) => list.indexOf(item) === index);
+      selectedIds = nextIds;
       hidden.value = nextIds.join(', ');
       onChange(nextIds.join(', '));
     };
@@ -2844,6 +2845,8 @@
       try {
         const playlist = await youtube.createPlaylist(title);
         setSelectedIds([...selectedIds, playlist.id]);
+        saveSavedYouTubePlaylists([...known.filter(item => item.id !== playlist.id), playlist]);
+        renderStages();
       } catch (error) {
         updateAppStatus(error.message || 'Unable to create YouTube playlist.', 'error');
         input.focus();


### PR DESCRIPTION
## Summary
- Refresh pipeline playlist choices immediately after creating a new YouTube playlist.
- Keep the current checkbox selection in sync so a newly created playlist is added alongside already selected playlists.
- Add a Cypress assertion that the created playlist appears in the checkbox list and is checked.

Fixes Jhon-Crow/audio-recorder-with-visualization#169

## Testing
- PASS: `npm test`
- PASS: `npm run build`
- PARTIAL: `npm run test:e2e -- --spec cypress/e2e/pipeline-mode.cy.js` ran the full pipeline suite; the playlist creation test passed, but the suite has an unrelated failure in `shows a fixed numbered stage navigator that scrolls to pipeline stages without narrowing cards` expecting the clicked stage nav button to have `is-active`.
