### PR TITLE
Refresh pipeline tooltip previews on visualization changes

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-23T03:29:18.842Z for PR creation at branch issue-171-5e93640ae894 for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/171

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-23T03:29:18.842Z for PR creation at branch issue-171-5e93640ae894 for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/171

--- a/cypress/e2e/pipeline-mode.cy.js
+++ b/cypress/e2e/pipeline-mode.cy.js
@@ -582,6 +582,69 @@ describe('Pipeline Mode', () => {
       });
   });
 
+  it('refreshes tooltip previews when the selected visualization preset changes', () => {
+    cy.window().then((win) => {
+      win.AudioRecorderPipeline.replaceStages([
+        {
+          kind: 'custom',
+          name: 'Refreshing tooltip preview',
+          action: 'visualize-upload',
+          resolution: '1920x1080',
+          presetId: 'preset:preset-cypress-bars',
+          scheduleMode: 'absolute',
+          publishAtLocal: '2026-08-01T12:00',
+        },
+      ]);
+    });
+
+    let initialPreviewImage = '';
+    cy.get('.pipeline-stage').eq(0).find('.pipeline-stage-number.pipeline-preview-trigger')
+      .should('have.attr', 'data-preview-state', 'ready')
+      .then(($trigger) => {
+        initialPreviewImage = $trigger[0].style.getPropertyValue('--pipeline-preview-image');
+        expect(initialPreviewImage).to.match(/^url\("data:image\/png;base64,/);
+      });
+
+    cy.window().then((win) => {
+      const presets = JSON.parse(win.localStorage.getItem('audio-recorder-presets'));
+      win.localStorage.setItem('audio-recorder-presets', JSON.stringify(presets.map((preset) => (
+        preset.id === 'preset-cypress-bars'
+          ? {
+            ...preset,
+            name: 'Cypress Bars Updated',
+            settings: {
+              ...preset.settings,
+              visualizer: 'circular',
+              primaryColor: '#ffffff',
+              secondaryColor: '#ffffff',
+              backgroundColor: '#000000',
+              backgroundImage: null,
+              offsetX: 480,
+              offsetY: -180,
+              visualizationScale: 120,
+            },
+          }
+          : preset
+      ))));
+    });
+    cy.reload();
+    cy.waitForVisualization();
+    cy.contains('.tab', 'Pipeline').click();
+
+    cy.get('.pipeline-stage').eq(0).find('.pipeline-stage-number.pipeline-preview-trigger')
+      .should('have.attr', 'data-preview-state', 'ready')
+      .and('have.attr', 'data-tooltip')
+      .should('contain', 'Stage 1 preview: 1920x1080, Cypress Bars Updated');
+
+    cy.get('.pipeline-stage').eq(0).find('.pipeline-stage-number.pipeline-preview-trigger')
+      .then(($trigger) => {
+        const refreshedPreviewImage = $trigger[0].style.getPropertyValue('--pipeline-preview-image');
+        expect(refreshedPreviewImage).to.match(/^url\("data:image\/png;base64,/);
+        expect(refreshedPreviewImage).to.not.equal(initialPreviewImage);
+        expectPreviewBrightSpotNear(refreshedPreviewImage, 0.63, 0.39);
+      });
+  });
+
   it('shows fetched YouTube playlists in pipeline stages and creates playlists by name', () => {
     cy.clearLocalStorage();
     cy.intercept('GET', 'https://www.googleapis.com/youtube/v3/playlists*', {

--- a/examples/app-core.js
+++ b/examples/app-core.js
@@ -1422,6 +1422,11 @@ window.AudioRecorderApp = window.AudioRecorderApp || {};
   // Helper function to show preview after settings change
   function updatePreview() {
     updatePreviewGuides();
+    window.dispatchEvent(new CustomEvent('audioRecorderVisualizationSettingsChanged', {
+      detail: {
+        settings: getCurrentSettings(),
+      },
+    }));
     // Show demo visualization if no audio source is active
     if (!recorder.sourceType) {
       recorder.showDemoVisualization(500);

--- a/examples/pipeline.js
+++ b/examples/pipeline.js
@@ -1298,6 +1298,11 @@
     return promise;
   }
 
+  function resetPipelinePreviewCache() {
+    pipelinePreviewCache.clear();
+    hidePipelinePreviewTooltip();
+  }
+
   function applyPipelinePreviewTooltip(element, stage, labelPrefix) {
     element.classList.add('pipeline-preview-trigger');
     element.dataset.tooltip = getPreviewLabel(stage, labelPrefix);
@@ -3558,7 +3563,13 @@
     }
   });
   window.addEventListener('audioRecorderPresetsChanged', () => {
+    resetPipelinePreviewCache();
     refreshStagePresetSelections();
+    renderStages();
+  });
+  window.addEventListener('audioRecorderVisualizationSettingsChanged', () => {
+    resetPipelinePreviewCache();
+    renderStages();
   });
   window.addEventListener('audioRecorderYouTubePlaylistsChanged', () => {
     renderStages();
@@ -3573,6 +3584,7 @@
     replaceStages(nextStages) {
       selectedFilesByStageId.clear();
       selectedCoversByStageId.clear();
+      resetPipelinePreviewCache();
       stages = Array.isArray(nextStages) ? nextStages.map(normalizeStage) : [];
       saveStages();
       renderStages();


### PR DESCRIPTION
Fixes Jhon-Crow/audio-recorder-with-visualization#171.\n\n## Summary\n- dispatch a visualization-settings change event whenever the main preview is refreshed\n- clear and regenerate pipeline tooltip preview images when visualization settings or saved presets change\n- add a Cypress regression covering a selected preset changing from one visualization preview to another\n\n## Testing\n- npm test\n- npm run build\n- npm run typecheck\n- npm run test:e2e -- --spec cypress/e2e/pipeline-mode.cy.js (new regression passes; existing navigator assertion at cypress/e2e/pipeline-mode.cy.js:256 still fails)