### PR TITLE
Add review step before pipeline YouTube upload

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-23T03:37:48.659Z for PR creation at branch issue-173-4a84f26ae816 for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/173

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-23T03:37:48.659Z for PR creation at branch issue-173-4a84f26ae816 for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/173

--- a/cypress/e2e/pipeline-mode.cy.js
+++ b/cypress/e2e/pipeline-mode.cy.js
@@ -990,6 +990,116 @@ describe('Pipeline Mode', () => {
     cy.get('#resetPipelineFieldsBtn').should('be.visible');
   });
 
+  it('reviews rendered visualization uploads before YouTube upload and can skip them', () => {
+    cy.window().then((win) => {
+      win.AudioRecorderPipeline.replaceStages([
+        {
+          name: 'Review before upload',
+          action: 'visualize-upload',
+          resolution: '1920x1080',
+          presetId: 'preset:preset-cypress-bars',
+          scheduleMode: 'absolute',
+          publishAtLocal: '2026-08-01T12:00',
+        },
+      ]);
+    });
+    cy.get('.pipeline-stage').first().find('.pipeline-stage-file-input').selectFile({
+      contents: Cypress.Buffer.from('stage-audio'),
+      fileName: 'review-me.mp3',
+      mimeType: 'audio/mpeg',
+    }, { force: true });
+
+    cy.window().then((win) => {
+      win.localStorage.setItem('audio-recorder-youtube-token-state', JSON.stringify({
+        accessToken: 'stored-token',
+        accessTokenExpiresAt: Date.now() + 3600 * 1000,
+        tokenScope: combinedYouTubeScope,
+      }));
+      cy.stub(win.AudioRecorderYouTube, 'hasValidAccessToken').returns(true);
+      cy.stub(win.AudioRecorderYouTube, 'uploadDirect').as('pipelineUploadDirect').resolves({
+        id: 'should-not-upload',
+      });
+      cy.stub(win.AudioRecorderApp.converter, 'convertWithFallback').resolves({
+        blob: new win.Blob(['rendered-video'], { type: 'video/webm' }),
+        format: 'webm',
+        usedFallback: false,
+      }).as('pipelineConvertForReview');
+    });
+
+    cy.get('#runPipelineBtn').should('not.be.disabled').click();
+
+    cy.get('@pipelineConvertForReview').should('have.been.calledOnce');
+    cy.get('#pipelineReportModal').should('be.visible');
+    cy.get('#pipelineReviewList').should('be.visible').and('contain.text', 'Review before upload');
+    cy.get('@pipelineUploadDirect').should('not.have.been.called');
+    cy.get('#pipelineReviewList video').should('have.attr', 'src').and('match', /^blob:/);
+    cy.get('#confirmPipelineUploadsBtn').should('be.visible');
+    cy.get('#skipPipelineUploadsBtn').should('be.visible').click();
+
+    cy.get('@pipelineUploadDirect').should('not.have.been.called');
+    cy.get('#pipelineReviewList').should('not.be.visible');
+    cy.get('#pipelineReportSummary').should('contain.text', 'Pipeline complete: 1 task finished');
+    cy.get('#status').should('contain.text', 'YouTube upload skipped');
+  });
+
+  it('uploads reviewed visualization results only after confirmation', () => {
+    cy.window().then((win) => {
+      win.AudioRecorderPipeline.replaceStages([
+        {
+          name: 'Confirmed upload',
+          action: 'visualize-upload',
+          resolution: '1920x1080',
+          presetId: 'preset:preset-cypress-bars',
+          scheduleMode: 'absolute',
+          publishAtLocal: '2026-08-01T12:00',
+        },
+      ]);
+    });
+    cy.get('.pipeline-stage').first().find('.pipeline-stage-description').type('Reviewed description');
+    cy.get('.pipeline-stage').first().find('.pipeline-stage-file-input').selectFile({
+      contents: Cypress.Buffer.from('stage-audio'),
+      fileName: 'confirm-me.mp3',
+      mimeType: 'audio/mpeg',
+    }, { force: true });
+
+    cy.window().then((win) => {
+      win.localStorage.setItem('audio-recorder-youtube-token-state', JSON.stringify({
+        accessToken: 'stored-token',
+        accessTokenExpiresAt: Date.now() + 3600 * 1000,
+        tokenScope: combinedYouTubeScope,
+      }));
+      cy.stub(win.AudioRecorderYouTube, 'hasValidAccessToken').returns(true);
+      cy.stub(win.AudioRecorderYouTube, 'uploadDirect').as('pipelineUploadDirect').resolves({
+        id: 'reviewed-video-id',
+        url: 'https://www.youtube.com/watch?v=reviewed-video-id',
+      });
+      cy.stub(win.AudioRecorderApp.converter, 'convertWithFallback').resolves({
+        blob: new win.Blob(['rendered-video'], { type: 'video/webm' }),
+        format: 'webm',
+        usedFallback: false,
+      });
+    });
+
+    cy.get('#runPipelineBtn').should('not.be.disabled').click();
+    cy.get('#pipelineReportModal').should('be.visible');
+    cy.get('#pipelineReviewList').should('be.visible').and('contain.text', 'Confirmed upload');
+    cy.get('@pipelineUploadDirect').should('not.have.been.called');
+    cy.get('#confirmPipelineUploadsBtn').click();
+
+    cy.get('@pipelineUploadDirect').should('have.been.calledOnce');
+    cy.window().then((win) => {
+      cy.get('@pipelineUploadDirect').then((uploadDirect) => {
+        const call = uploadDirect.getCall(0).args[0];
+        expect(call.video).to.be.instanceOf(win.Blob);
+        expect(call.metadata.title).to.equal('Confirmed upload');
+        expect(call.metadata.description).to.equal('Reviewed description');
+      });
+    });
+    cy.get('#pipelineReviewList').should('not.be.visible');
+    cy.get('#pipelineReportList').should('contain.text', 'Confirmed upload');
+    cy.get('#pipelineReportList').should('contain.text', 'reviewed-video-id');
+  });
+
   it('uploads direct YouTube stages with stage metadata when already signed in', () => {
     cy.intercept('POST', 'https://www.googleapis.com/upload/youtube/v3/videos*', (req) => {
       const body = typeof req.body === 'string' ? JSON.parse(req.body) : req.body;

--- a/cypress/e2e/pipeline-mode.cy.js
+++ b/cypress/e2e/pipeline-mode.cy.js
@@ -675,6 +675,16 @@ describe('Pipeline Mode', () => {
     });
   });
 
+  it('keeps upload review enabled by default and can disable it from settings', () => {
+    cy.get('#pipelineSettingsBtn').click();
+    cy.get('#pipelineReviewBeforeUpload').should('be.checked').uncheck();
+    cy.get('#confirmPipelineTimezoneBtn').click();
+
+    cy.window().then((win) => {
+      expect(win.localStorage.getItem('audio-recorder-pipeline-review-before-upload')).to.equal('false');
+    });
+  });
+
   it('deletes a stage only after confirmation', () => {
     cy.get('#clearPipelineBtn').click();
     cy.get('#addPipelineStageBtn').click();
@@ -1098,6 +1108,56 @@ describe('Pipeline Mode', () => {
     cy.get('#pipelineReviewList').should('not.be.visible');
     cy.get('#pipelineReportList').should('contain.text', 'Confirmed upload');
     cy.get('#pipelineReportList').should('contain.text', 'reviewed-video-id');
+  });
+
+  it('uploads rendered visualization results immediately when review is disabled', () => {
+    cy.get('#pipelineSettingsBtn').click();
+    cy.get('#pipelineReviewBeforeUpload').uncheck();
+    cy.get('#confirmPipelineTimezoneBtn').click();
+
+    cy.window().then((win) => {
+      win.AudioRecorderPipeline.replaceStages([
+        {
+          name: 'Immediate upload',
+          action: 'visualize-upload',
+          resolution: '1920x1080',
+          presetId: 'preset:preset-cypress-bars',
+          scheduleMode: 'absolute',
+          publishAtLocal: '2026-08-01T12:00',
+        },
+      ]);
+    });
+    cy.get('.pipeline-stage').first().find('.pipeline-stage-file-input').selectFile({
+      contents: Cypress.Buffer.from('stage-audio'),
+      fileName: 'immediate-upload.mp3',
+      mimeType: 'audio/mpeg',
+    }, { force: true });
+
+    cy.window().then((win) => {
+      win.localStorage.setItem('audio-recorder-youtube-token-state', JSON.stringify({
+        accessToken: 'stored-token',
+        accessTokenExpiresAt: Date.now() + 3600 * 1000,
+        tokenScope: combinedYouTubeScope,
+      }));
+      cy.stub(win.AudioRecorderYouTube, 'hasValidAccessToken').returns(true);
+      cy.stub(win.AudioRecorderYouTube, 'uploadDirect').as('pipelineUploadDirect').resolves({
+        id: 'immediate-video-id',
+        url: 'https://www.youtube.com/watch?v=immediate-video-id',
+      });
+      cy.stub(win.AudioRecorderApp.converter, 'convertWithFallback').resolves({
+        blob: new win.Blob(['rendered-video'], { type: 'video/webm' }),
+        format: 'webm',
+        usedFallback: false,
+      });
+    });
+
+    cy.get('#runPipelineBtn').should('not.be.disabled').click();
+
+    cy.get('@pipelineUploadDirect').should('have.been.calledOnce');
+    cy.get('#pipelineReportModal').should('be.visible');
+    cy.get('#pipelineReviewList').should('not.be.visible');
+    cy.get('#pipelineReportList').should('contain.text', 'Immediate upload');
+    cy.get('#pipelineReportList').should('contain.text', 'immediate-video-id');
   });
 
   it('uploads direct YouTube stages with stage metadata when already signed in', () => {

--- a/examples/index.html
+++ b/examples/index.html
@@ -980,9 +980,12 @@
       </div>
       <div class="modal-body">
         <p id="pipelineReportSummary"></p>
+        <div id="pipelineReviewList" class="pipeline-review-list" style="display: none;"></div>
         <ol id="pipelineReportList" class="pipeline-report-list"></ol>
       </div>
       <div class="modal-footer">
+        <button id="skipPipelineUploadsBtn" type="button" class="btn" style="display: none;">Skip YouTube upload</button>
+        <button id="confirmPipelineUploadsBtn" type="button" class="btn btn-primary" style="display: none;">Upload to YouTube</button>
         <button id="closePipelineReportBtn" type="button" class="btn btn-primary">Done</button>
       </div>
     </div>

--- a/examples/index.html
+++ b/examples/index.html
@@ -964,6 +964,10 @@
             <option value="manual">Allow manual order</option>
           </select>
         </label>
+        <label class="pipeline-modal-field pipeline-modal-checkbox" data-tooltip="When enabled, rendered visualization uploads pause so you can preview, download, upload, or skip them.">
+          <input type="checkbox" id="pipelineReviewBeforeUpload" checked aria-label="Review rendered videos before YouTube upload">
+          Review rendered videos before YouTube upload
+        </label>
       </div>
       <div class="modal-footer">
         <button id="cancelPipelineTimezoneBtn" type="button" class="btn">Cancel</button>

--- a/examples/pipeline.js
+++ b/examples/pipeline.js
@@ -10,6 +10,7 @@
   const ACTIVE_PIPELINE_KEY = 'audio-recorder-active-pipeline-id';
   const PIPELINE_TIMEZONE_KEY = 'audio-recorder-pipeline-timezone';
   const PIPELINE_UPLOAD_ORDER_KEY = 'audio-recorder-pipeline-upload-order';
+  const PIPELINE_REVIEW_BEFORE_UPLOAD_KEY = 'audio-recorder-pipeline-review-before-upload';
   const RESET_OPTIONS_KEY = 'audio-recorder-pipeline-reset-options';
   const PLAYLISTS_KEY = 'audio-recorder-youtube-playlists';
   const HOLD_TO_RESET_MS = 600;
@@ -69,6 +70,7 @@
   const timezoneModal = document.getElementById('pipelineTimezoneModal');
   const timezoneSelect = document.getElementById('pipelineTimezoneSelect');
   const uploadOrderSelect = document.getElementById('pipelineUploadOrderSelect');
+  const reviewBeforeUploadCheckbox = document.getElementById('pipelineReviewBeforeUpload');
   const cancelTimezoneBtn = document.getElementById('cancelPipelineTimezoneBtn');
   const cancelTimezoneXBtn = document.getElementById('cancelPipelineTimezoneXBtn');
   const confirmTimezoneBtn = document.getElementById('confirmPipelineTimezoneBtn');
@@ -89,7 +91,8 @@
     pipelineRenameModal, pipelineRenameInput, pipelineCancelRenameBtn, pipelineConfirmRenameBtn,
     deleteModal, deleteMessage, cancelDeleteBtn, cancelDeleteXBtn,
     confirmDeleteBtn, resetModal, cancelResetBtn, cancelResetXBtn, confirmResetHoldBtn,
-    timezoneModal, timezoneSelect, uploadOrderSelect, cancelTimezoneBtn, cancelTimezoneXBtn, confirmTimezoneBtn,
+    timezoneModal, timezoneSelect, uploadOrderSelect, reviewBeforeUploadCheckbox,
+    cancelTimezoneBtn, cancelTimezoneXBtn, confirmTimezoneBtn,
     reportModal, reportSummary, reviewList, reportList, closeReportBtn, closeReportXBtn,
     skipUploadsBtn, confirmUploadsBtn,
     ...Object.values(resetCheckboxes),
@@ -121,6 +124,7 @@
   let pipelineUploadOrder = localStorage.getItem(PIPELINE_UPLOAD_ORDER_KEY) === 'manual'
     ? 'manual'
     : 'chronological';
+  let pipelineReviewBeforeUpload = localStorage.getItem(PIPELINE_REVIEW_BEFORE_UPLOAD_KEY) !== 'false';
   let pendingDeleteStageId = '';
   let hasPipelineRun = false;
   let isPipelineRunning = false;
@@ -2059,6 +2063,10 @@
 
     const rendered = await renderTask(task, taskIndex, totalTasks);
     if (task.stage.action === 'visualize-upload') {
+      if (!pipelineReviewBeforeUpload) {
+        const result = await uploadTask(task, rendered.blob, taskIndex, totalTasks);
+        return { type: 'uploaded', report: createUploadReport(task, result) };
+      }
       return {
         type: 'review',
         item: {
@@ -3265,6 +3273,7 @@
       createdAt: new Date().toISOString(),
       timezone: pipelineTimezone,
       uploadOrder: pipelineUploadOrder,
+      reviewBeforeUpload: pipelineReviewBeforeUpload,
       stages: stages.map(sanitizeStage),
     };
     savedPipelines = [...savedPipelines, pipeline];
@@ -3282,12 +3291,14 @@
     stages = Array.isArray(pipeline.stages) ? pipeline.stages.map(normalizeStage) : [];
     pipelineTimezone = pipeline.timezone || pipelineTimezone;
     pipelineUploadOrder = pipeline.uploadOrder === 'manual' ? 'manual' : 'chronological';
+    pipelineReviewBeforeUpload = pipeline.reviewBeforeUpload !== false;
     activePipelineId = pipeline.id;
     localStorage.setItem(ACTIVE_PIPELINE_KEY, activePipelineId);
     if (pipelineTimezone) {
       localStorage.setItem(PIPELINE_TIMEZONE_KEY, pipelineTimezone);
     }
     localStorage.setItem(PIPELINE_UPLOAD_ORDER_KEY, pipelineUploadOrder);
+    localStorage.setItem(PIPELINE_REVIEW_BEFORE_UPLOAD_KEY, String(pipelineReviewBeforeUpload));
     saveStages();
     updateTimezoneButton();
     renderStages();
@@ -3533,6 +3544,7 @@
     }
     timezoneSelect.value = currentTimezone;
     uploadOrderSelect.value = pipelineUploadOrder;
+    reviewBeforeUploadCheckbox.checked = pipelineReviewBeforeUpload;
     timezoneModal.style.display = 'flex';
   }
 
@@ -3549,8 +3561,10 @@
   function saveTimezone() {
     pipelineTimezone = timezoneSelect.value || getBrowserTimezone();
     pipelineUploadOrder = uploadOrderSelect.value === 'manual' ? 'manual' : 'chronological';
+    pipelineReviewBeforeUpload = reviewBeforeUploadCheckbox.checked;
     localStorage.setItem(PIPELINE_TIMEZONE_KEY, pipelineTimezone);
     localStorage.setItem(PIPELINE_UPLOAD_ORDER_KEY, pipelineUploadOrder);
+    localStorage.setItem(PIPELINE_REVIEW_BEFORE_UPLOAD_KEY, String(pipelineReviewBeforeUpload));
     updateTimezoneButton();
     closeTimezoneModal();
     updateRunState();

--- a/examples/pipeline.js
+++ b/examples/pipeline.js
@@ -75,9 +75,12 @@
 
   const reportModal = document.getElementById('pipelineReportModal');
   const reportSummary = document.getElementById('pipelineReportSummary');
+  const reviewList = document.getElementById('pipelineReviewList');
   const reportList = document.getElementById('pipelineReportList');
   const closeReportBtn = document.getElementById('closePipelineReportBtn');
   const closeReportXBtn = document.getElementById('closePipelineReportXBtn');
+  const skipUploadsBtn = document.getElementById('skipPipelineUploadsBtn');
+  const confirmUploadsBtn = document.getElementById('confirmPipelineUploadsBtn');
 
   const requiredElements = [
     addStageBtn, clearPipelineBtn, runPipelineBtn, resetPipelineFieldsBtn, pipelineTimezoneBtn,
@@ -87,7 +90,8 @@
     deleteModal, deleteMessage, cancelDeleteBtn, cancelDeleteXBtn,
     confirmDeleteBtn, resetModal, cancelResetBtn, cancelResetXBtn, confirmResetHoldBtn,
     timezoneModal, timezoneSelect, uploadOrderSelect, cancelTimezoneBtn, cancelTimezoneXBtn, confirmTimezoneBtn,
-    reportModal, reportSummary, reportList, closeReportBtn, closeReportXBtn,
+    reportModal, reportSummary, reviewList, reportList, closeReportBtn, closeReportXBtn,
+    skipUploadsBtn, confirmUploadsBtn,
     ...Object.values(resetCheckboxes),
   ];
 
@@ -130,6 +134,7 @@
   let activePipelineMenuId = null;
   let pipelineRenameTargetId = null;
   let draggedPipelineId = null;
+  let pendingUploadReview = null;
 
   function createId(prefix) {
     return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -2015,6 +2020,23 @@
     });
   }
 
+  function createObjectUrl(blob) {
+    return window.URL && typeof window.URL.createObjectURL === 'function'
+      ? window.URL.createObjectURL(blob)
+      : '';
+  }
+
+  function revokeReviewUrls(items = []) {
+    if (!window.URL || typeof window.URL.revokeObjectURL !== 'function') {
+      return;
+    }
+    items.forEach(item => {
+      if (item.previewUrl) {
+        window.URL.revokeObjectURL(item.previewUrl);
+      }
+    });
+  }
+
   function assertUploadReady(tasks) {
     if (!tasks.some(task => actionIncludesUpload(task.stage.action))) {
       return;
@@ -2032,15 +2054,22 @@
   async function executePipelineTask(task, taskIndex, totalTasks) {
     if (task.stage.action === 'upload-youtube') {
       const result = await uploadTask(task, task.file, taskIndex, totalTasks);
-      return createUploadReport(task, result);
+      return { type: 'uploaded', report: createUploadReport(task, result) };
     }
 
     const rendered = await renderTask(task, taskIndex, totalTasks);
     if (task.stage.action === 'visualize-upload') {
-      const result = await uploadTask(task, rendered.blob, taskIndex, totalTasks);
-      return createUploadReport(task, result);
+      return {
+        type: 'review',
+        item: {
+          task,
+          video: rendered.blob,
+          format: rendered.format || getRequestedVideoFormat(getPipelineApp()),
+          previewUrl: createObjectUrl(rendered.blob),
+        },
+      };
     }
-    return null;
+    return { type: 'rendered' };
   }
 
   function createUploadReport(task, result = {}) {
@@ -2072,10 +2101,60 @@
   }
 
   function hidePipelineReport() {
+    if (pendingUploadReview) {
+      revokeReviewUrls(pendingUploadReview.items);
+      pendingUploadReview = null;
+    }
     reportModal.style.display = 'none';
   }
 
+  function setReportMode(mode) {
+    const isReview = mode === 'review';
+    reviewList.style.display = isReview ? '' : 'none';
+    reportList.style.display = isReview ? 'none' : '';
+    skipUploadsBtn.style.display = isReview ? '' : 'none';
+    confirmUploadsBtn.style.display = isReview ? '' : 'none';
+    closeReportBtn.style.display = isReview ? 'none' : '';
+  }
+
+  function showPipelineReview(reviewItems, existingReports, totalTasks) {
+    pendingUploadReview = { items: reviewItems, reports: existingReports, totalTasks };
+    setReportMode('review');
+    reportSummary.textContent = `${reviewItems.length} rendered video${reviewItems.length === 1 ? '' : 's'} ready for review before YouTube upload.`;
+    reviewList.innerHTML = '';
+    reviewItems.forEach(({ task, previewUrl, format }, index) => {
+      const item = document.createElement('article');
+      item.className = 'pipeline-review-item';
+
+      const video = document.createElement('video');
+      video.className = 'pipeline-review-video';
+      video.controls = true;
+      video.src = previewUrl;
+
+      const details = document.createElement('div');
+      details.className = 'pipeline-review-details';
+      const title = document.createElement('strong');
+      title.textContent = task.title || `Rendered video ${index + 1}`;
+      const meta = document.createElement('span');
+      meta.textContent = `${format || 'video'} · Publish date: ${formatReportDate(task.publishAt)}`;
+      const download = document.createElement('a');
+      download.href = previewUrl;
+      download.download = `${(task.title || `pipeline-video-${index + 1}`).replace(/[^a-z0-9]+/gi, '-').replace(/^-|-$/g, '').toLowerCase() || `pipeline-video-${index + 1}`}.${format || 'webm'}`;
+      download.textContent = 'Download';
+      details.appendChild(title);
+      details.appendChild(meta);
+      details.appendChild(download);
+
+      item.appendChild(video);
+      item.appendChild(details);
+      reviewList.appendChild(item);
+    });
+    reportModal.style.display = 'flex';
+    confirmUploadsBtn.focus();
+  }
+
   function showPipelineReport(uploadReports = [], totalTasks = 0) {
+    setReportMode('report');
     reportSummary.textContent = uploadReports.length
       ? `Pipeline complete: ${totalTasks} task${totalTasks === 1 ? '' : 's'} finished, ${uploadReports.length} YouTube upload${uploadReports.length === 1 ? '' : 's'} scheduled.`
       : `Pipeline complete: ${totalTasks} task${totalTasks === 1 ? '' : 's'} finished.`;
@@ -2126,6 +2205,55 @@
     reportModal.style.display = 'flex';
   }
 
+  async function confirmReviewedUploads() {
+    if (!pendingUploadReview || isPipelineRunning) {
+      return;
+    }
+
+    const review = pendingUploadReview;
+    pendingUploadReview = null;
+    isPipelineRunning = true;
+    updateRunState();
+    setReportMode('report');
+    reportSummary.textContent = 'Uploading reviewed videos to YouTube...';
+    try {
+      const uploadReports = [...review.reports];
+      for (let index = 0; index < review.items.length; index++) {
+        const item = review.items[index];
+        const result = await uploadTask(item.task, item.video, index, review.items.length);
+        uploadReports.push(createUploadReport(item.task, result));
+      }
+      revokeReviewUrls(review.items);
+      updateAppStatus(
+        `Pipeline complete: ${review.totalTasks} task${review.totalTasks === 1 ? '' : 's'} finished`,
+        'ready'
+      );
+      showPipelineReport(uploadReports, review.totalTasks);
+    } catch (error) {
+      pendingUploadReview = review;
+      setReportMode('review');
+      updateAppStatus(`Pipeline upload failed: ${error.message || 'Unknown error'}`, 'error');
+    } finally {
+      isPipelineRunning = false;
+      updateRunState();
+    }
+  }
+
+  function skipReviewedUploads() {
+    if (!pendingUploadReview) {
+      return;
+    }
+
+    const review = pendingUploadReview;
+    revokeReviewUrls(review.items);
+    pendingUploadReview = null;
+    updateAppStatus(
+      `Pipeline complete: ${review.totalTasks} task${review.totalTasks === 1 ? '' : 's'} finished, YouTube upload skipped`,
+      'ready'
+    );
+    showPipelineReport(review.reports, review.totalTasks);
+  }
+
   async function runPipeline() {
     if (isPipelineRunning) return;
 
@@ -2150,11 +2278,14 @@
     try {
       assertUploadReady(tasks);
       const uploadReports = [];
+      const reviewItems = [];
 
       for (let index = 0; index < tasks.length; index++) {
-        const report = await executePipelineTask(tasks[index], index, tasks.length);
-        if (report) {
-          uploadReports.push(report);
+        const result = await executePipelineTask(tasks[index], index, tasks.length);
+        if (result?.type === 'uploaded') {
+          uploadReports.push(result.report);
+        } else if (result?.type === 'review') {
+          reviewItems.push(result.item);
         }
       }
 
@@ -2162,7 +2293,11 @@
         `Pipeline complete: ${tasks.length} task${tasks.length === 1 ? '' : 's'} finished`,
         'ready'
       );
-      showPipelineReport(uploadReports, tasks.length);
+      if (reviewItems.length) {
+        showPipelineReview(reviewItems, uploadReports, tasks.length);
+      } else {
+        showPipelineReport(uploadReports, tasks.length);
+      }
     } catch (error) {
       console.error('Pipeline failed:', error);
       updateAppStatus(`Pipeline failed: ${error.message || 'Unknown error'}`, 'error');
@@ -3486,6 +3621,8 @@
   confirmTimezoneBtn.addEventListener('click', saveTimezone);
   closeReportBtn.addEventListener('click', hidePipelineReport);
   closeReportXBtn.addEventListener('click', hidePipelineReport);
+  skipUploadsBtn.addEventListener('click', skipReviewedUploads);
+  confirmUploadsBtn.addEventListener('click', confirmReviewedUploads);
 
   savePipelineBtn.addEventListener('click', saveCurrentPipeline);
 

--- a/examples/styles.css
+++ b/examples/styles.css
@@ -1817,6 +1817,11 @@ button:focus-visible {
   align-items: stretch;
 }
 
+.pipeline-modal-checkbox {
+  flex-direction: row;
+  align-items: center;
+}
+
 .pipeline-modal-field select {
   width: 100%;
   padding: 10px 12px;

--- a/examples/styles.css
+++ b/examples/styles.css
@@ -1743,6 +1743,45 @@ button:focus-visible {
   background: rgba(255, 255, 255, 0.04);
 }
 
+.pipeline-review-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.pipeline-review-item {
+  display: grid;
+  grid-template-columns: minmax(180px, 240px) 1fr;
+  gap: var(--spacing-md);
+  align-items: center;
+  padding: 12px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.pipeline-review-video {
+  width: 100%;
+  max-height: 160px;
+  border-radius: var(--radius-sm);
+  background: #000;
+}
+
+.pipeline-review-details {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 6px;
+  color: var(--color-text-secondary);
+  font-size: 13px;
+}
+
+.pipeline-review-details strong {
+  overflow-wrap: anywhere;
+  color: var(--color-text-primary);
+  font-size: 15px;
+}
+
 .pipeline-report-title {
   display: flex;
   flex-wrap: wrap;
@@ -1822,6 +1861,10 @@ button:focus-visible {
   }
 
   .pipeline-stage {
+    grid-template-columns: 1fr;
+  }
+
+  .pipeline-review-item {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
## Summary
- Adds a review checkpoint for pipeline stages that render visualizations before YouTube upload.
- Shows rendered videos in the pipeline report modal with playback and download links.
- Adds a default-enabled pipeline settings checkbox to review rendered videos before YouTube upload.
- Lets users disable that checkbox to upload rendered visualization results immediately without the review step.
- Keeps direct upload-only pipeline stages working as before.

Fixes Jhon-Crow/audio-recorder-with-visualization#173

## Tests
- npm test
- npm run build
- node --check examples/pipeline.js
- git diff --check
- npx cypress run --config baseUrl=http://localhost:8094 --spec cypress/e2e/pipeline-mode.cy.js (28 passing; 1 existing navigator assertion failure: `shows a fixed numbered stage navigator that scrolls to pipeline stages without narrowing cards` timed out expecting `is-active`)

## E2E note
- Added Cypress coverage for skipping reviewed uploads, uploading only after confirmation, the default-enabled review checkbox, and immediate upload when review is disabled.
- Local Cypress was run against a repo-root server on port 8094. The new review-toggle tests passed; one unrelated pre-existing stage navigator assertion remains flaky locally.