### PR TITLE
Fix YouTube pipeline follow-up upload errors

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-23T03:50:10.935Z for PR creation at branch issue-175-642a0b1a0d65 for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/175

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-23T03:50:10.935Z for PR creation at branch issue-175-642a0b1a0d65 for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/175

--- a/examples/pipeline.js
+++ b/examples/pipeline.js
@@ -2051,7 +2051,20 @@
       url: result.url || (result.id ? `https://www.youtube.com/watch?v=${result.id}` : ''),
       publishAt,
       playlistIds: task.stage.playlistIds || '',
+      warnings: Array.isArray(result.warnings) ? result.warnings : [],
     };
+  }
+
+  function formatYouTubeWarning(warning) {
+    const parts = [];
+    if (warning.playlistId) {
+      parts.push(`playlist ${warning.playlistId}`);
+    } else if (warning.operation) {
+      parts.push(warning.operation);
+    }
+
+    parts.push(warning.message || 'Unknown warning');
+    return parts.join(': ');
   }
 
   function formatReportDate(value) {
@@ -2118,6 +2131,13 @@
           playlists.className = 'pipeline-report-playlists';
           playlists.textContent = `Playlists: ${report.playlistIds}`;
           item.appendChild(playlists);
+        }
+
+        if (report.warnings && report.warnings.length) {
+          const warnings = document.createElement('div');
+          warnings.className = 'pipeline-report-warnings';
+          warnings.textContent = `Warnings: ${report.warnings.map(formatYouTubeWarning).join('; ')}`;
+          item.appendChild(warnings);
         }
 
         reportList.appendChild(item);

--- a/examples/youtube-upload.js
+++ b/examples/youtube-upload.js
@@ -150,6 +150,25 @@
     link.rel = 'noopener';
     link.textContent = result.id;
     uploadStatus.appendChild(link);
+
+    if (Array.isArray(result.warnings) && result.warnings.length) {
+      uploadStatus.appendChild(document.createElement('br'));
+      uploadStatus.appendChild(document.createTextNode(
+        `Warnings: ${result.warnings.map(formatYouTubeWarning).join('; ')}`
+      ));
+    }
+  }
+
+  function formatYouTubeWarning(warning) {
+    const parts = [];
+    if (warning.playlistId) {
+      parts.push(`playlist ${warning.playlistId}`);
+    } else if (warning.operation) {
+      parts.push(warning.operation);
+    }
+
+    parts.push(warning.message || 'Unknown warning');
+    return parts.join(': ');
   }
 
   function getPlaylistIds(value) {

--- a/src/core/YouTubeUploader.ts
+++ b/src/core/YouTubeUploader.ts
@@ -67,8 +67,11 @@ export interface YouTubeUploadResult {
   id: string;
   url: string;
   thumbnail?: unknown;
+  thumbnailError?: YouTubeUploadWarning;
   playlistItem?: unknown;
   playlistItems?: unknown[];
+  playlistErrors?: YouTubeUploadWarning[];
+  warnings?: YouTubeUploadWarning[];
   rawResponse: unknown;
 }
 
@@ -85,6 +88,14 @@ export interface YouTubeVideoResource {
     containsSyntheticMedia?: boolean;
     publishAt?: string;
   };
+}
+
+export interface YouTubeUploadWarning {
+  operation: 'thumbnail' | 'playlist';
+  message: string;
+  status?: number;
+  details?: unknown;
+  playlistId?: string;
 }
 
 type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
@@ -367,13 +378,22 @@ export class YouTubeUploader {
     const result = await this.uploadChunks(fetchImpl, uploadUrl, request, contentType);
 
     if (request.thumbnail && request.thumbnail.size > 0) {
-      result.thumbnail = await this.uploadThumbnail(
-        fetchImpl,
-        request.accessToken,
-        result.id,
-        request.thumbnail,
-        request.signal
-      );
+      try {
+        result.thumbnail = await this.uploadThumbnail(
+          fetchImpl,
+          request.accessToken,
+          result.id,
+          request.thumbnail,
+          request.signal
+        );
+      } catch (error) {
+        if (isAbortError(error)) {
+          throw error;
+        }
+
+        result.thumbnailError = normalizeUploadWarning('thumbnail', error);
+        result.warnings = [...(result.warnings || []), result.thumbnailError];
+      }
     }
 
     const playlistIds = normalizeYouTubePlaylistIds([
@@ -385,13 +405,23 @@ export class YouTubeUploader {
       result.playlistItems = [];
 
       for (const playlistId of playlistIds) {
-        result.playlistItems.push(await this.addVideoToPlaylist(
-          fetchImpl,
-          request.accessToken,
-          playlistId,
-          result.id,
-          request.signal
-        ));
+        try {
+          result.playlistItems.push(await this.addVideoToPlaylist(
+            fetchImpl,
+            request.accessToken,
+            playlistId,
+            result.id,
+            request.signal
+          ));
+        } catch (error) {
+          if (isAbortError(error)) {
+            throw error;
+          }
+
+          const warning = normalizeUploadWarning('playlist', error, playlistId);
+          result.playlistErrors = [...(result.playlistErrors || []), warning];
+          result.warnings = [...(result.warnings || []), warning];
+        }
       }
 
       result.playlistItem = result.playlistItems[0];
@@ -508,7 +538,10 @@ export class YouTubeUploader {
 
   private async createError(response: Response, fallbackMessage: string): Promise<YouTubeUploadError> {
     const details = await readResponseBody(response);
-    const message = extractErrorMessage(details) || fallbackMessage;
+    const detailMessage = extractErrorMessage(details);
+    const message = detailMessage
+      ? `${fallbackMessage}: ${detailMessage} (HTTP ${response.status})`
+      : `${fallbackMessage} (HTTP ${response.status})`;
     return new YouTubeUploadError(message, response.status, details);
   }
 
@@ -664,6 +697,32 @@ function extractErrorMessage(value: unknown): string | null {
   }
 
   return typeof value.message === 'string' ? value.message : null;
+}
+
+function normalizeUploadWarning(
+  operation: YouTubeUploadWarning['operation'],
+  error: unknown,
+  playlistId?: string
+): YouTubeUploadWarning {
+  const warning: YouTubeUploadWarning = {
+    operation,
+    message: error instanceof Error ? error.message : String(error || 'Unknown error'),
+  };
+
+  if (error instanceof YouTubeUploadError) {
+    warning.status = error.status;
+    warning.details = error.details;
+  }
+
+  if (playlistId) {
+    warning.playlistId = playlistId;
+  }
+
+  return warning;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/tests/YouTubeUploader.test.ts
+++ b/tests/YouTubeUploader.test.ts
@@ -349,6 +349,45 @@ describe('YouTubeUploader', () => {
       expect(JSON.parse(secondPlaylistInit.body as string).snippet.playlistId).toBe('PL456');
     });
 
+    test('returns the uploaded video with warnings when playlist follow-up fails', async () => {
+      const fetchMock = createFetchMock();
+      fetchMock
+        .mockResolvedValueOnce(createResponse(null, {
+          status: 200,
+          headers: { Location: 'https://upload.example/session' },
+        }))
+        .mockResolvedValueOnce(createResponse(JSON.stringify({ id: 'video-123' }), {
+          status: 201,
+        }))
+        .mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+      const uploader = new YouTubeUploader({ fetch: fetchMock });
+      const result = await uploader.upload({
+        video: new Blob(['video'], { type: 'video/webm' }),
+        accessToken: 'token-123',
+        metadata: {
+          title: 'Audio visualizer',
+          playlistIds: 'PL123',
+        },
+      });
+
+      expect(result).toMatchObject({
+        id: 'video-123',
+        url: 'https://www.youtube.com/watch?v=video-123',
+        playlistItems: [],
+        playlistErrors: [{
+          operation: 'playlist',
+          playlistId: 'PL123',
+          message: 'Failed to fetch',
+        }],
+        warnings: [{
+          operation: 'playlist',
+          playlistId: 'PL123',
+          message: 'Failed to fetch',
+        }],
+      });
+    });
+
     test('continues after a 308 resumable response', async () => {
       const fetchMock = createFetchMock();
       fetchMock
@@ -395,7 +434,7 @@ describe('YouTubeUploader', () => {
         video: new Blob(['video'], { type: 'video/webm' }),
         accessToken: 'token-123',
         metadata: { title: 'Failed upload' },
-      })).rejects.toThrow('Quota exceeded');
+      })).rejects.toThrow('Unable to start YouTube upload session: Quota exceeded (HTTP 403)');
     });
 
     test('rejects empty videos before calling the API', async () => {


### PR DESCRIPTION
Fixes Jhon-Crow/audio-recorder-with-visualization#175

## Summary
- Keep a confirmed YouTube video upload result when post-upload follow-up calls fail, such as playlist insertion or thumbnail upload.
- Return structured upload warnings with operation, playlist id, HTTP status, and response details when available.
- Show warnings in the single-upload status and the pipeline report instead of stopping the pipeline after the video is already uploaded.
- Include API fallback context and HTTP status in thrown YouTube upload errors.

## Reproduction Covered
- Added a unit test where the resumable video upload succeeds, then playlist insertion throws `Failed to fetch`; the upload now resolves with the video URL and a warning.

## Tests
- `npm test -- --runTestsByPath tests/YouTubeUploader.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run build`