### PR TITLE
Make YouTube authorization automatic from pipeline Run

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-23T03:54:19.780Z for PR creation at branch issue-177-9abeda2579e9 for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/177

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-23T03:54:19.780Z for PR creation at branch issue-177-9abeda2579e9 for issue https://github.com/Jhon-Crow/audio-recorder-with-visualization/issues/177

--- a/cypress/e2e/pipeline-mode.cy.js
+++ b/cypress/e2e/pipeline-mode.cy.js
@@ -1106,6 +1106,63 @@ describe('Pipeline Mode', () => {
       .should('have.attr', 'href', 'https://www.youtube.com/watch?v=pipeline-video-id');
   });
 
+  it('starts YouTube authorization from Run for upload stages without a separate YouTube click', () => {
+    cy.intercept('POST', 'https://www.googleapis.com/upload/youtube/v3/videos*', (req) => {
+      expect(req.headers.authorization).to.equal('Bearer electron-token');
+
+      req.reply({
+        statusCode: 200,
+        headers: { Location: 'https://upload.example/pipeline-auth-session' },
+        body: '',
+      });
+    }).as('startPipelineUpload');
+
+    cy.intercept('PUT', 'https://upload.example/pipeline-auth-session', {
+      statusCode: 201,
+      body: { id: 'pipeline-auth-video-id' },
+    }).as('finishPipelineUpload');
+
+    cy.reload();
+    cy.visit('/examples/index.html', {
+      onBeforeLoad(win) {
+        seedSavedVisualizationPresets(win);
+        win.localStorage.setItem('audio-recorder-youtube-client-id', '123-desktop-client-id.apps.googleusercontent.com');
+        win.electronAPI = {
+          isElectron: true,
+          authorizeYouTube: cy.stub().as('authorizeYouTube').resolves({
+            accessToken: 'electron-token',
+            expiresIn: 3600,
+            scope: combinedYouTubeScope,
+          }),
+        };
+      },
+    });
+    cy.waitForVisualization();
+    cy.contains('.tab', 'Pipeline').click();
+
+    cy.get('#clearPipelineBtn').click();
+    cy.get('#addPipelineStageBtn').click();
+    cy.get('.pipeline-stage').first().find('.pipeline-stage-name').clear().type('Run authorizes upload');
+    cy.get('.pipeline-stage').first().find('select').first().select('upload-youtube');
+    cy.get('.pipeline-stage').first().find('.pipeline-stage-file-input').selectFile({
+      contents: Cypress.Buffer.from('stage-video'),
+      fileName: 'direct-video.webm',
+      mimeType: 'video/webm',
+    }, { force: true });
+
+    cy.get('#runPipelineBtn').should('not.be.disabled').click();
+
+    cy.get('@authorizeYouTube')
+      .should('have.been.calledOnce')
+      .and('have.been.calledWith', '123-desktop-client-id.apps.googleusercontent.com');
+    cy.wait('@startPipelineUpload');
+    cy.wait('@finishPipelineUpload');
+    cy.get('#youtubeAuthModal').should('not.be.visible');
+    cy.get('#status').should('contain.text', 'Pipeline complete: 1 task finished');
+    cy.get('#pipelineReportList a')
+      .should('have.attr', 'href', 'https://www.youtube.com/watch?v=pipeline-auth-video-id');
+  });
+
   it('keeps generated tooltip boxes inside the viewport', () => {
     cy.viewport(360, 640);
     cy.get('.pipeline-stage').first().find('.pipeline-file-btn').trigger('mouseover');

--- a/examples/pipeline.js
+++ b/examples/pipeline.js
@@ -2017,13 +2017,27 @@
 
   function assertUploadReady(tasks) {
     if (!tasks.some(task => actionIncludesUpload(task.stage.action))) {
-      return;
+      return false;
     }
 
     const youtube = window.AudioRecorderYouTube;
     if (!youtube || typeof youtube.uploadDirect !== 'function') {
       throw new Error('YouTube upload is not ready. Run npm run build before using upload pipeline stages.');
     }
+    return true;
+  }
+
+  async function ensureUploadReady(tasks) {
+    if (!assertUploadReady(tasks)) {
+      return;
+    }
+
+    const youtube = window.AudioRecorderYouTube;
+    if (typeof youtube.ensureAuthorizedForPipeline === 'function') {
+      await youtube.ensureAuthorizedForPipeline();
+      return;
+    }
+
     if (typeof youtube.hasValidAccessToken === 'function' && !youtube.hasValidAccessToken()) {
       throw new Error('Sign in to YouTube before running upload pipeline stages.');
     }
@@ -2148,7 +2162,7 @@
     updateRunState();
 
     try {
-      assertUploadReady(tasks);
+      await ensureUploadReady(tasks);
       const uploadReports = [];
 
       for (let index = 0; index < tasks.length; index++) {

--- a/examples/youtube-upload.js
+++ b/examples/youtube-upload.js
@@ -1029,8 +1029,22 @@
     }
   }
 
+  async function ensureAuthorizedForPipeline() {
+    if (hasValidAccessToken()) {
+      return true;
+    }
+
+    if (await restoreElectronYouTubeAuthorization()) {
+      return true;
+    }
+
+    openAuthModal();
+    throw new Error('Complete YouTube sign-in, then run the pipeline again.');
+  }
+
   window.AudioRecorderYouTube = {
     createPlaylist: createYouTubePlaylist,
+    ensureAuthorizedForPipeline,
     getSavedPlaylists: loadSavedYouTubePlaylists,
     hasValidAccessToken,
     hasPlaylistScope,


### PR DESCRIPTION
## Summary
- Let pipeline upload stages request/restore YouTube authorization from the Run button instead of failing before upload work starts.
- Reuse the existing Electron OAuth restoration path and fall back to opening the YouTube sign-in modal for browser/manual sign-in.
- Add a Cypress regression covering Run-triggered Electron authorization and upload without a separate YouTube button click.

Fixes Jhon-Crow/audio-recorder-with-visualization#177

## Testing
- PASS: npm test -- --runInBand
- PASS: npm run typecheck
- PARTIAL: npx cypress run --spec cypress/e2e/pipeline-mode.cy.js
  - New regression test passed: "starts YouTube authorization from Run for upload stages without a separate YouTube click".
  - Full spec had 2 unrelated pre-existing UI interaction failures in stage navigator/reset tests: active stage nav class timeout and hidden stage name input during clear().